### PR TITLE
Add epochs per gauge for AERO distribution and claim cycle in AeroManager

### DIFF
--- a/contracts/src/AeroManager.sol
+++ b/contracts/src/AeroManager.sol
@@ -164,21 +164,19 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
         emit Claimed(gauge, claimedAmount, _claimFee, currentEpoch);
     }
 
-    function distributeAero(address[] memory gauges, AeroRecipient[][] memory recipients) external onlyGovernor {
-        require(gauges.length == recipients.length, "AeroManager: Gauges and recipients length mismatch");
-        for (uint256 i; i < gauges.length; i++) {
-            uint256 currentEpoch = currentEpochs[gauges[i]];
-            uint256 rewardAmount = claimedAeroPerEpoch[currentEpoch][gauges[i]];
-            for (uint256 j; j < recipients[i].length; j++) {
-                require(recipients[i][j].amount <= rewardAmount, "AeroManager: Total amount exceeds reward amount");
-                rewardAmount -= recipients[i][j].amount;
-                claimableRewards[recipients[i][j].borrower] += recipients[i][j].amount;
-            }
-            require(rewardAmount == 0, "AeroManager: Reward amount not fully distributed");
-            emit AeroDistributed(gauges[i], recipients[i].length, rewardAmount, currentEpoch);
-            currentEpoch++;
-            currentEpochs[gauges[i]] = currentEpoch;
+    function distributeAero(address gauge, AeroRecipient[] memory recipients) external onlyGovernor {
+        require(recipients.length > 0, "AeroManager: No recipients");
+        uint256 currentEpoch = currentEpochs[gauge];
+        uint256 rewardAmount = claimedAeroPerEpoch[currentEpoch][gauge];
+        for (uint256 i; i < recipients.length; i++) {
+            require(recipients[i].amount <= rewardAmount, "AeroManager: Total amount exceeds reward amount");
+            rewardAmount -= recipients[i].amount;
+            claimableRewards[recipients[i].borrower] += recipients[i].amount;
         }
+        require(rewardAmount == 0, "AeroManager: Reward amount not fully distributed");
+        emit AeroDistributed(gauge, recipients.length, rewardAmount, currentEpoch);
+        currentEpoch++;
+        currentEpochs[gauge] = currentEpoch;
     }
 
     function claimRewards(address user) external nonReentrant {

--- a/contracts/src/AeroManager.sol
+++ b/contracts/src/AeroManager.sol
@@ -28,12 +28,20 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     mapping(address gauge => uint256) public stakedAmounts;
     mapping(address activePool => bool) public activePools;
 
-    uint256 public claimedAero;
-
     mapping(address gauge => uint256 epoch) public currentEpochs;
     mapping(uint256 epoch => mapping(address gauge => uint256 amount)) public claimedAeroPerEpoch;
 
     mapping(address user => uint256 amount) public claimableRewards;
+
+    uint256 public claimedAero;
+    
+    uint256 public claimFee;
+
+    uint256 public pendingNewClaimFee;
+
+    uint256 public pendingNewClaimFeeTimestamp;
+    
+    uint256 public claimFeeChangeDelayPeriod = 7 days;
 
     event Staked(address indexed gauge, address token, uint256 amount);
     event ActivePoolAdded(address indexed activePool);
@@ -43,14 +51,6 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     event CollateralRegistryAdded(address collateralRegistry);
     event ClaimFeeUpdated(uint256 oldFee, uint256 newFee);
     event ClaimFeeUpdatePending(uint256 oldFee, uint256 newFee, uint256 timestamp, uint256 delayPeriod);
-    
-    uint256 public claimFee;
-
-    uint256 public pendingNewClaimFee;
-
-    uint256 public pendingNewClaimFeeTimestamp;
-    
-    uint256 public claimFeeChangeDelayPeriod = 7 days;
 
     constructor(address _aeroTokenAddress, address _governor, address _treasuryAddress) {
         require(_treasuryAddress != address(0), "AeroManager: Treasury address cannot be 0");


### PR DESCRIPTION
closes #42 

Claimed AERO is sorted by gauge and epoch for cleaner distribution cycles. Once distributed, the AERO from that epoch and gauge are then accumulated by user address. The user address is based on last owner of each trove that has been active within the epoch. TRUST ASSUMPTION: We assume the backend will distribute to correct user address as last known owner of TroveID. Since troves can close within an epoch, it may cause an issue sorting by TroveID instead of last known owner of that trove.