### PR TITLE
Fix AeroLPTokenPriceFeed price calculation from pool using TWAP

### DIFF
--- a/contracts/test/TestContracts/AeroGaugeMock.sol
+++ b/contracts/test/TestContracts/AeroGaugeMock.sol
@@ -26,7 +26,8 @@ contract AeroPoolMock {
     uint256 internal _reserve0;
     uint256 internal _reserve1;
     uint256 internal _totalSupply;
-    uint256 internal _quoteAmountOut;
+    uint256 internal _quoteToken0ToToken1; // How much token1 for 1 token0
+    uint256 internal _quoteToken1ToToken0; // How much token0 for 1 token1
 
     bool internal _shouldRevert;
 
@@ -52,8 +53,12 @@ contract AeroPoolMock {
         _totalSupply = supply;
     }
     
-    function setQuoteAmountOut(uint256 amountOut) external {
-        _quoteAmountOut = amountOut;
+    /// @notice Set quote amounts for both directions
+    /// @param token0ToToken1 How much token1 returned when quoting 1 unit of token0
+    /// @param token1ToToken0 How much token0 returned when quoting 1 unit of token1
+    function setQuoteAmounts(uint256 token0ToToken1, uint256 token1ToToken0) external {
+        _quoteToken0ToToken1 = token0ToToken1;
+        _quoteToken1ToToken0 = token1ToToken0;
     }
 
     function setShouldRevert(bool v) external {
@@ -71,9 +76,14 @@ contract AeroPoolMock {
         return _totalSupply;
     }
     
-    function quote(address, uint256, uint256) external view returns (uint256) {
+    function quote(address tokenIn, uint256, uint256) external view returns (uint256) {
         if (_shouldRevert) revert("AeroPoolMock: revert");
-        return _quoteAmountOut;
+        // Return appropriate quote based on input token direction
+        if (tokenIn == token0) {
+            return _quoteToken0ToToken1;
+        } else {
+            return _quoteToken1ToToken0;
+        }
     }
 
     // Legacy getter (kept for backward compatibility)

--- a/contracts/test/TestContracts/AeroLPTokenPriceFeedTester.sol
+++ b/contracts/test/TestContracts/AeroLPTokenPriceFeedTester.sol
@@ -22,8 +22,8 @@ contract AeroLPTokenPriceFeedTester is AeroLPTokenPriceFeed {
         )
     {}
 
-    function i_getTwapExchangeRate() external view returns (uint256 token1PerToken0, bool isDown) {
-        return _getTwapExchangeRate();
+    function i_getTwapExchangeRates() external view returns (ExchangeRate memory exchangeRate) {
+        return _getTwapExchangeRates();
     }
     
     function i_getPoolState() external view returns (


### PR DESCRIPTION
closes #60 

This PR fixes 2 issues found:
1. Using `currentCumulativePrices()` from pool (aka the "spot" prices) instead of TWAP which could make it vulnerable to price manipulation via flash loans on the underlying Aerodrome pool.
2. Incorrect USD price value calculation of the LP token. Previous way was returning the exchange rate of token0 per token1.

For 1, we now get the `quote()` amount of each token per the other which returns the TWAP amount based on a granularity of 8 periods (30 minute intervals * 8 = 4 hour period).
For 2, we get both TWAP exchange rates of `token0` amount per 1 `token1` and vice versa and multiply that by the oracle USD price of the denominator token to get a "market" USD price of each token from the pool. Then we compare it to the oracle price of the numerator token and pick the price of each by redemption and deviation threshold (like before).

The final output USD price of the LP token is (found in `_calculateLPTokenPrice`):
```
price = ((reserve0 * token0Price / 1e18) + (reserve1 * token1Price / 1e18)) * 1e18 / totalSupply
```