### PR TITLE
ActivePool Fix + Fuzzing, Invariants and E2E testing on Aero LP token collaterals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ CLAUDE.md
 package-lock.json
 
 .env
+
+.agents/
+.cursor/
+.opencode/

--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -181,10 +181,8 @@ contract ActivePool is IActivePool {
 
         _accountForSendColl(_amount);
 
-        if (isAeroLPCollateral) {
-            // IAeroGauge(aeroGaugeAddress).withdraw(_amount);
-            IAeroManager(aeroManagerAddress).withdraw(aeroGaugeAddress, address(collToken), _amount);
-        }
+        _unstakeIfAeroLPCollateral(_amount);
+
         collToken.safeTransfer(_account, _amount);
     }
 
@@ -192,6 +190,8 @@ contract ActivePool is IActivePool {
         _requireCallerIsTroveManager();
 
         _accountForSendColl(_amount);
+
+        _unstakeIfAeroLPCollateral(_amount);
 
         IDefaultPool(defaultPoolAddress).receiveColl(_amount);
     }
@@ -228,6 +228,14 @@ contract ActivePool is IActivePool {
             // Then AeroManager deposits the _amount into AeroGauge
             // IAeroGauge(aeroGaugeAddress).deposit(_amount);
             IAeroManager(aeroManagerAddress).stake(aeroGaugeAddress, address(collToken), _amount);
+        }
+    }
+
+    function _unstakeIfAeroLPCollateral(uint256 _amount) internal {
+        if (isAeroLPCollateral) {
+            // AeroManager withdraws the _amount from AeroGauge
+            // IAeroGauge(aeroGaugeAddress).withdraw(_amount);
+            IAeroManager(aeroManagerAddress).withdraw(aeroGaugeAddress, address(collToken), _amount);
         }
     }
 

--- a/contracts/test/AeroLPE2E.t.sol
+++ b/contracts/test/AeroLPE2E.t.sol
@@ -1,0 +1,585 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "forge-std/Test.sol";
+import "./TestContracts/Accounts.sol";
+import "./TestContracts/AeroGaugeTester.sol";
+import "./TestContracts/Deployment.t.sol";
+import "./TestContracts/WETHTester.sol";
+import "src/AeroManager.sol";
+import {LatestTroveData} from "src/Types/LatestTroveData.sol";
+import {ETH_GAS_COMPENSATION} from "src/Dependencies/Constants.sol";
+
+/**
+ * @title AeroLPE2E
+ * @notice End-to-end tests for Aero LP collateral
+ * @dev Tests liquidations, non-redeemability, urgent redemptions, and shutdown scenarios
+ */
+contract AeroLPE2E is Test, TestAccounts {
+    // Gauge
+    AeroGaugeTester internal gauge;
+    MockAeroToken internal aeroToken;
+
+    // Branch references
+    TestDeployer.LiquityContractsDev internal aeroLPBranch;
+    TestDeployer.LiquityContractsDev internal normalBranch;
+    TestDeployer.LiquityContractsDev[] internal branches;
+
+    // Core contracts
+    IAeroManager internal aeroManager;
+    ICollateralRegistry internal collateralRegistry;
+    IBoldToken internal boldToken;
+    HintHelpers internal hintHelpers;
+    IWETH internal WETH;
+
+    // Collateral tokens
+    IERC20 internal lpToken;
+    IERC20 internal normalCollToken;
+
+    // Constants
+    uint256 constant INITIAL_PRICE = 200e18;
+    uint256 constant MIN_DEBT = 2000e18;
+    uint256 constant CCR_BUFFER = 10e16; // 10% buffer above CCR
+
+    function setUp() public virtual {
+        // Start tests at a non-zero timestamp
+        vm.warp(block.timestamp + 600);
+
+        accounts = new Accounts();
+        createAccounts();
+
+        (A, B, C, D, E, F, G) = (
+            accountsList[0],
+            accountsList[1],
+            accountsList[2],
+            accountsList[3],
+            accountsList[4],
+            accountsList[5],
+            accountsList[6]
+        );
+
+        TestDeployer deployer = new TestDeployer();
+
+        // Create WETHTester first
+        WETHTester wethTester = new WETHTester(100 ether, 1 days);
+
+        // Create gauge with WETHTester as staking token
+        gauge = new AeroGaugeTester(address(wethTester), deployer.AERO_TOKEN_ADDRESS());
+        aeroToken = MockAeroToken(gauge.rewardToken());
+
+        // Deploy 2 branches: 1 Aero LP (non-redeemable) + 1 normal (redeemable)
+        TestDeployer.TroveManagerParams[] memory troveManagerParamsArray = new TestDeployer.TroveManagerParams[](2);
+
+        // Branch 0: Aero LP collateral (non-redeemable)
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams({
+            CCR: 150e16,
+            MCR: 110e16,
+            BCR: 10e16,
+            SCR: 110e16,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 5e16,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 10e16,
+            isAeroLPCollateral: true,
+            aeroGaugeAddress: address(gauge)
+        });
+
+        // Branch 1: Normal collateral (redeemable)
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams({
+            CCR: 150e16,
+            MCR: 110e16,
+            BCR: 10e16,
+            SCR: 110e16,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 5e16,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 10e16,
+            isAeroLPCollateral: false,
+            aeroGaugeAddress: address(0)
+        });
+
+        // Deploy contracts
+        TestDeployer.DeployAndConnectContractsResults memory result =
+            deployer.deployAndConnectContracts(troveManagerParamsArray, IWETH(address(wethTester)));
+
+        // Store references
+        aeroLPBranch = result.contractsArray[0];
+        normalBranch = result.contractsArray[1];
+        for (uint256 i = 0; i < result.contractsArray.length; i++) {
+            branches.push(result.contractsArray[i]);
+        }
+
+        aeroManager = result.aeroManager;
+        collateralRegistry = result.collateralRegistry;
+        boldToken = result.boldToken;
+        hintHelpers = result.hintHelpers;
+        WETH = IWETH(address(wethTester));
+
+        lpToken = aeroLPBranch.collToken;
+        normalCollToken = normalBranch.collToken;
+
+        // Give collateral to test accounts
+        uint256 initialCollAmount = 10_000_000e18;
+        for (uint256 i = 0; i < 6; i++) {
+            // Aero LP collateral
+            deal(address(lpToken), accountsList[i], initialCollAmount);
+            vm.prank(accountsList[i]);
+            lpToken.approve(address(aeroLPBranch.borrowerOperations), type(uint256).max);
+            // Normal collateral
+            deal(address(normalCollToken), accountsList[i], initialCollAmount);
+            vm.prank(accountsList[i]);
+            normalCollToken.approve(address(normalBranch.borrowerOperations), type(uint256).max);
+            // WETH for gas compensation
+            deal(address(WETH), accountsList[i], 100 ether);
+            vm.prank(accountsList[i]);
+            WETH.approve(address(aeroLPBranch.borrowerOperations), type(uint256).max);
+            vm.prank(accountsList[i]);
+            WETH.approve(address(normalBranch.borrowerOperations), type(uint256).max);
+        }
+    }
+
+    // ============ Helper Functions ============
+
+    function _openTroveOnBranch(
+        TestDeployer.LiquityContractsDev memory _branch,
+        uint256 branchIndex,
+        address _account,
+        uint256 _coll,
+        uint256 _boldAmount,
+        uint256 _annualInterestRate
+    ) internal returns (uint256 troveId) {
+        // Check if collateral token is the same as WETH
+        bool collIsWeth = address(_branch.collToken) == address(WETH);
+        
+        if (collIsWeth) {
+            // If collateral IS WETH, deal both collateral AND gas compensation together
+            deal(address(WETH), _account, _coll + 1 ether);
+        } else {
+            // Otherwise deal them separately
+            deal(address(_branch.collToken), _account, _coll + 1e18);
+            deal(address(WETH), _account, 1 ether);
+        }
+        
+        vm.prank(_account);
+        _branch.collToken.approve(address(_branch.borrowerOperations), type(uint256).max);
+        vm.prank(_account);
+        WETH.approve(address(_branch.borrowerOperations), type(uint256).max);
+        
+        uint256 upfrontFee = hintHelpers.predictOpenTroveUpfrontFee(
+            branchIndex, _boldAmount, _annualInterestRate
+        );
+
+        vm.startPrank(_account);
+        troveId = _branch.borrowerOperations.openTrove(
+            _account,
+            0, // index
+            _coll,
+            _boldAmount,
+            0, // upperHint
+            0, // lowerHint
+            _annualInterestRate,
+            upfrontFee,
+            address(0),
+            address(0),
+            address(0)
+        );
+        vm.stopPrank();
+    }
+
+    function _getMinColl(uint256 debt, uint256 price, uint256 ratio) internal pure returns (uint256) {
+        return debt * ratio / price + 1e18;
+    }
+
+    function _getAeroManager() internal view returns (AeroManager) {
+        return AeroManager(address(aeroManager));
+    }
+
+    // ============ Liquidation Flow Tests ============
+
+    /**
+     * @notice Test liquidation with Aero LP collateral flows correctly
+     */
+    function test_liquidationWithAeroLPCollateral() public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        
+        uint256 debt = 100_000e18;
+        // Open at exactly CCR so we can easily make it liquidatable
+        uint256 coll = _getMinColl(debt, price, ccr + 5e16); // Just above CCR
+        uint256 interestRate = 5e16;
+
+        // Open two troves (need at least one to liquidate another)
+        uint256 troveIdA = _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        _openTroveOnBranch(aeroLPBranch, 0, B, coll * 3, debt, interestRate); // B has much more collateral
+
+        // Fund stability pool
+        deal(address(boldToken), C, debt * 10);
+        vm.prank(C);
+        aeroLPBranch.stabilityPool.provideToSP(debt * 10, true);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 apBalanceBefore = aeroLPBranch.activePool.getCollBalance();
+
+        // Drop price by 50% to make A's trove liquidatable
+        uint256 newPrice = price / 2;
+        aeroLPBranch.priceFeed.setPrice(newPrice);
+
+        // Liquidate A
+        aeroLPBranch.troveManager.liquidate(troveIdA);
+
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 apBalanceAfter = aeroLPBranch.activePool.getCollBalance();
+
+        // Verify collateral was unstaked and moved
+        assertTrue(stakedAfter < stakedBefore, "Staked amount should decrease after liquidation");
+        assertTrue(apBalanceAfter < apBalanceBefore, "ActivePool balance should decrease");
+        assertEq(stakedAfter, apBalanceAfter, "Staked should match AP balance");
+    }
+
+    /**
+     * @notice Test redistribution with Aero LP collateral
+     * @dev When a liquidation occurs without SP funds, collateral is redistributed to other troves
+     *      via DefaultPool. This tests that AeroManager properly unstakes during redistribution.
+     */
+    function test_redistributionWithAeroLPCollateral() public {
+        // Setup: Open two troves - A (low coll ratio) and B (high coll ratio)
+        (uint256 troveIdA, uint256 troveIdB, uint256 collA, uint256 collB) = _setupRedistributionTroves();
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+        
+        // Verify initial state
+        assertEq(stakedBefore, aeroLPBranch.activePool.getCollBalance(), "Initial: Staked should match AP balance");
+        assertEq(gauge.balanceOf(address(aeroManager)), stakedBefore, "Initial: Gauge balance should match staked");
+
+        // Drop price by 50% to make trove A liquidatable (A opened just above CCR)
+        uint256 mcr = aeroLPBranch.troveManager.get_MCR();
+        uint256 newPrice = aeroLPBranch.priceFeed.getPrice() / 2;
+        aeroLPBranch.priceFeed.setPrice(newPrice);
+
+        // Verify A is liquidatable, B survives
+        assertTrue(aeroLPBranch.troveManager.getCurrentICR(troveIdA, newPrice) < mcr, "Trove A should be liquidatable");
+        assertTrue(aeroLPBranch.troveManager.getCurrentICR(troveIdB, newPrice) >= mcr, "Trove B should survive");
+
+        // Verify SP is empty (redistribution path)
+        assertEq(aeroLPBranch.stabilityPool.getTotalBoldDeposits(), 0, "SP should be empty");
+
+        // Record B's collateral before liquidation
+        uint256 troveCollBBefore = aeroLPBranch.troveManager.getLatestTroveData(troveIdB).entireColl;
+
+        // Liquidate A - redistributes to B
+        aeroLPBranch.troveManager.liquidate(troveIdA);
+
+        // Verify A is closed
+        assertTrue(
+            aeroLPBranch.troveManager.getTroveStatus(troveIdA) == ITroveManager.Status.closedByLiquidation,
+            "Trove A should be closed by liquidation"
+        );
+
+        // Check accounting after redistribution
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 apBalanceAfter = aeroLPBranch.activePool.getCollBalance();
+        uint256 defaultPoolBalance = aeroLPBranch.pools.defaultPool.getCollBalance();
+
+        // Key invariants for Aero LP:
+        assertEq(stakedAfter, apBalanceAfter, "Staked should match AP balance after redistribution");
+        assertEq(gauge.balanceOf(address(aeroManager)), stakedAfter, "Gauge balance should match staked");
+        
+        // Total collateral preserved in pools (ActivePool + DefaultPool)
+        // Note: Gas compensation (WETH) is sent to liquidator, not counted in pools
+        assertApproxEqAbs(
+            apBalanceAfter + defaultPoolBalance,
+            collA + collB,
+            1e18, // Allow for gas compensation and rounding
+            "Total collateral should be approximately preserved"
+        );
+
+        // Trove B received redistributed collateral
+        assertTrue(
+            aeroLPBranch.troveManager.getLatestTroveData(troveIdB).entireColl > troveCollBBefore,
+            "Trove B should have received redistributed collateral"
+        );
+    }
+
+    /// @dev Helper to set up troves for redistribution test
+    function _setupRedistributionTroves() internal returns (uint256 troveIdA, uint256 troveIdB, uint256 collA, uint256 collB) {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        
+        uint256 debtA = 50_000e18;
+        uint256 debtB = 100_000e18;
+        
+        collA = _getMinColl(debtA, price, ccr + 1e16); // Just above CCR - will be liquidatable after 50% price drop
+        collB = _getMinColl(debtB, price, ccr * 3);     // 3x CCR - survives 50% price drop
+        
+        troveIdA = _openTroveOnBranch(aeroLPBranch, 0, A, collA, debtA, 5e16);
+        troveIdB = _openTroveOnBranch(aeroLPBranch, 0, B, collB, debtB, 5e16);
+    }
+
+    // ============ Non-Redeemability Tests ============
+
+    /**
+     * @notice Test redemption behavior with Aero LP branches
+     * @dev NOTE: Current test deployer registers ALL branches as redeemable in the constructor.
+     *      Non-redeemability of Aero LP branches requires using createNewBranch() with isRedeemable=false.
+     *      This test verifies that gauge accounting remains consistent during redemption.
+     */
+    function test_redemptionGaugeAccountingAeroLP() public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        
+        uint256 debt = 100_000e18;
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        // Open trove on Aero LP branch
+        _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+
+        // Give C BOLD to redeem
+        uint256 redeemAmount = debt / 4;
+        deal(address(boldToken), C, redeemAmount);
+        vm.prank(C);
+        boldToken.approve(address(collateralRegistry), redeemAmount);
+
+        // Perform redemption
+        vm.prank(C);
+        collateralRegistry.redeemCollateral(redeemAmount, 10, 1e18);
+
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 apBalance = aeroLPBranch.activePool.getCollBalance();
+        uint256 gaugeBalance = gauge.balanceOf(address(aeroManager));
+
+        // Verify: Gauge accounting invariants hold after redemption
+        assertEq(stakedAfter, apBalance, "Staked should match AP balance after redemption");
+        assertEq(gaugeBalance, stakedAfter, "Gauge balance should match staked after redemption");
+        
+        // Since current deployer registers all branches as redeemable, 
+        // redemption will affect the Aero LP branch - verify proper unstaking occurred
+        assertTrue(stakedAfter <= stakedBefore, "Staked should not increase from redemption");
+    }
+
+    /**
+     * @notice Fuzz test: Normal redemption with mixed branches - verify gauge accounting consistency
+     */
+    function testFuzz_normalRedemptionWithMixedBranches(uint256 redeemSeed) public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        
+        uint256 debt = 100_000e18;
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        // Open troves on both branches
+        _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        _openTroveOnBranch(normalBranch, 1, B, coll, debt, interestRate);
+
+        // Bound redemption amount to a valid range that will succeed
+        uint256 redeemAmount = bound(redeemSeed, MIN_DEBT, debt / 2);
+
+        uint256 aeroLPStakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+
+        // Give C BOLD to redeem
+        deal(address(boldToken), C, redeemAmount);
+        vm.prank(C);
+        boldToken.approve(address(collateralRegistry), redeemAmount);
+
+        // Perform redemption - should succeed with our setup
+        vm.prank(C);
+        collateralRegistry.redeemCollateral(redeemAmount, 10, 1e18);
+
+        // Verify: Gauge accounting invariants always hold
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 apBalance = aeroLPBranch.activePool.getCollBalance();
+        uint256 gaugeBalance = gauge.balanceOf(address(aeroManager));
+
+        assertEq(stakedAfter, apBalance, "Staked should match AP balance after redemption");
+        assertEq(gaugeBalance, stakedAfter, "Gauge balance should match staked");
+        
+        // Note: Since current test deployer registers all branches as redeemable,
+        // the Aero LP branch may be affected. We verify accounting consistency instead.
+        assertTrue(stakedAfter <= aeroLPStakedBefore, "Staked should not increase from redemption");
+    }
+
+    // ============ Urgent Redemption Tests (Aero LP Specific - Gauge Unstaking) ============
+
+    /**
+     * @notice Test urgent redemption unstakes from gauge correctly
+     */
+    function test_urgentRedemption_unstakesFromGauge() public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        uint256 scr = aeroLPBranch.borrowerOperations.SCR();
+        
+        uint256 debt = 100_000e18;
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        // Open troves
+        uint256 troveIdA = _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        _openTroveOnBranch(aeroLPBranch, 0, B, coll * 2, debt, interestRate);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 gaugeBefore = gauge.balanceOf(address(aeroManager));
+
+        // Trigger shutdown by dropping price to make TCR < SCR
+        // Calculate price that puts TCR just below SCR
+        uint256 totalColl = aeroLPBranch.activePool.getCollBalance();
+        uint256 totalDebt = aeroLPBranch.troveManager.getEntireBranchDebt();
+        // TCR = totalColl * price / totalDebt
+        // For TCR < SCR: price < SCR * totalDebt / totalColl
+        uint256 shutdownPrice = (scr - 1e16) * totalDebt / totalColl; // Just below SCR
+        aeroLPBranch.priceFeed.setPrice(shutdownPrice);
+        
+        // Call shutdown
+        aeroLPBranch.borrowerOperations.shutdown();
+        
+        // Verify shutdown was triggered
+        assertTrue(aeroLPBranch.troveManager.shutdownTime() > 0, "Branch should be shutdown");
+            
+        // Give C BOLD for urgent redemption
+        deal(address(boldToken), C, debt * 2);
+        vm.prank(C);
+        boldToken.approve(address(aeroLPBranch.troveManager), type(uint256).max);
+
+        // Perform urgent redemption
+        uint256[] memory troveIds = new uint256[](1);
+        troveIds[0] = troveIdA;
+        
+        vm.prank(C);
+        aeroLPBranch.troveManager.urgentRedemption(debt, troveIds, 0);
+
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 gaugeAfter = gauge.balanceOf(address(aeroManager));
+
+        // Aero LP-specific assertions: Gauge properly unstaked
+        assertTrue(stakedAfter < stakedBefore, "Staked should decrease after urgent redemption");
+        assertTrue(gaugeAfter < gaugeBefore, "Gauge balance should decrease");
+        assertEq(stakedAfter, aeroLPBranch.activePool.getCollBalance(), "Staked should match AP balance");
+    }
+
+    /**
+     * @notice Fuzz test: Urgent redemption properly unstakes from gauge
+     */
+    function testFuzz_urgentRedemption_unstakesFromGauge(uint256 debtSeed) public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        uint256 scr = aeroLPBranch.borrowerOperations.SCR();
+        
+        uint256 debt = bound(debtSeed, MIN_DEBT, 1_000_000e18);
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        // Open troves
+        uint256 troveIdA = _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        _openTroveOnBranch(aeroLPBranch, 0, B, coll * 2, debt, interestRate);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+
+        // Trigger shutdown by dropping price to make TCR < SCR
+        uint256 totalColl = aeroLPBranch.activePool.getCollBalance();
+        uint256 totalDebt = aeroLPBranch.troveManager.getEntireBranchDebt();
+        uint256 shutdownPrice = (scr - 1e16) * totalDebt / totalColl;
+        aeroLPBranch.priceFeed.setPrice(shutdownPrice);
+        
+        // Call shutdown
+        aeroLPBranch.borrowerOperations.shutdown();
+        
+        // Verify shutdown was triggered
+        assertTrue(aeroLPBranch.troveManager.shutdownTime() > 0, "Branch should be shutdown");
+        
+        // Give C BOLD for urgent redemption
+        deal(address(boldToken), C, debt * 2);
+        vm.prank(C);
+        boldToken.approve(address(aeroLPBranch.troveManager), type(uint256).max);
+
+        uint256[] memory troveIds = new uint256[](1);
+        troveIds[0] = troveIdA;
+        
+        vm.prank(C);
+        aeroLPBranch.troveManager.urgentRedemption(debt, troveIds, 0);
+        
+        // Verify gauge unstaking
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+        assertTrue(stakedAfter < stakedBefore, "Staked should decrease");
+        assertEq(stakedAfter, aeroLPBranch.activePool.getCollBalance(), "Staked should match AP");
+    }
+
+    // ============ Shutdown Scenarios (Aero LP Specific) ============
+
+    /**
+     * @notice Test closing trove properly unstakes from gauge
+     * @dev This tests the core Aero LP functionality - collateral is unstaked when troves are closed
+     */
+    function test_closeTroveUnstakesFromGauge() public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        
+        uint256 debt = 100_000e18;
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        // Open troves
+        uint256 troveIdA = _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        _openTroveOnBranch(aeroLPBranch, 0, B, coll * 2, debt, interestRate);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 troveCollA = aeroLPBranch.troveManager.getLatestTroveData(troveIdA).entireColl;
+
+        // Users can close troves
+        uint256 troveDebtA = aeroLPBranch.troveManager.getTroveEntireDebt(troveIdA);
+        deal(address(boldToken), A, troveDebtA * 2);
+        
+        vm.startPrank(A);
+        boldToken.approve(address(aeroLPBranch.borrowerOperations), type(uint256).max);
+        aeroLPBranch.borrowerOperations.closeTrove(troveIdA);
+        vm.stopPrank();
+
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
+
+        // Aero LP-specific assertions
+        assertEq(stakedBefore - stakedAfter, troveCollA, "Staked should decrease by trove collateral");
+        assertEq(stakedAfter, aeroLPBranch.activePool.getCollBalance(), "Staked should match AP balance");
+        assertEq(gauge.balanceOf(address(aeroManager)), stakedAfter, "Gauge balance should match staked");
+    }
+
+    // ============ Normal Branch Behavior Verification ============
+
+    /**
+     * @notice Test that Aero LP branch behaves like normal branch for standard operations
+     */
+    function test_aeroLPBranchBehavesLikeNormalBranch() public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        
+        uint256 debt = 100_000e18;
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        // Test: Open trove works
+        uint256 troveId = _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        assertTrue(aeroLPBranch.troveNFT.ownerOf(troveId) == A, "A should own trove");
+
+        // Test: Interest accrues
+        vm.warp(block.timestamp + 365 days);
+        uint256 debtAfterYear = aeroLPBranch.troveManager.getTroveEntireDebt(troveId);
+        assertTrue(debtAfterYear > debt, "Debt should accrue interest");
+
+        // Test: Add collateral works
+        uint256 addColl = 10e18;
+        deal(address(lpToken), A, addColl);
+        vm.prank(A);
+        lpToken.approve(address(aeroLPBranch.borrowerOperations), addColl);
+        vm.prank(A);
+        aeroLPBranch.borrowerOperations.addColl(troveId, addColl);
+
+        uint256 newColl = aeroLPBranch.troveManager.getLatestTroveData(troveId).entireColl;
+        assertEq(newColl, coll + addColl, "Collateral should increase");
+
+        // Test: SP deposits work
+        deal(address(boldToken), B, debt);
+        vm.prank(B);
+        aeroLPBranch.stabilityPool.provideToSP(debt, true);
+        
+        uint256 spBalance = aeroLPBranch.stabilityPool.getCompoundedBoldDeposit(B);
+        assertEq(spBalance, debt, "SP deposit should be recorded");
+    }
+}

--- a/contracts/test/AeroLPFuzz.t.sol
+++ b/contracts/test/AeroLPFuzz.t.sol
@@ -1,0 +1,752 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "forge-std/Test.sol";
+import "./TestContracts/Accounts.sol";
+import "./TestContracts/AeroGaugeTester.sol";
+import "./TestContracts/Deployment.t.sol";
+import "./TestContracts/WETHTester.sol";
+import "src/AeroManager.sol";
+
+/**
+ * @title AeroLPFuzz
+ * @notice Fuzz tests for Aero LP collateral across multiple branches
+ * @dev Tests staking/unstaking via AeroManager, multi-gauge independence, and reward operations
+ */
+contract AeroLPFuzz is Test, TestAccounts {
+    // Gauges for each Aero LP branch
+    AeroGaugeTester internal gauge1;
+    AeroGaugeTester internal gauge2;
+    MockAeroToken internal aeroToken;
+
+    // Branch references
+    TestDeployer.LiquityContractsDev internal aeroLPBranch1;
+    TestDeployer.LiquityContractsDev internal aeroLPBranch2;
+    TestDeployer.LiquityContractsDev internal normalBranch;
+    TestDeployer.LiquityContractsDev[] internal branches;
+
+    // Collateral tokens
+    IERC20 internal lpToken1;
+    IERC20 internal lpToken2;
+    IERC20 internal normalCollToken;
+
+    // Core contracts
+    IAeroManager internal aeroManager;
+    ICollateralRegistry internal collateralRegistry;
+    IBoldToken internal boldToken;
+    HintHelpers internal hintHelpers;
+    IWETH internal WETH;
+
+    // Constants for fuzzing bounds
+    uint256 constant MIN_COLL = 1e18;
+    uint256 constant MAX_COLL = 1_000_000e18;
+    uint256 constant MIN_DEBT_AMOUNT = 2000e18;
+    uint256 constant MAX_DEBT = 10_000_000e18;
+    uint256 constant MIN_INTEREST_RATE = 5e15; // 0.5%
+    uint256 constant MAX_INTEREST_RATE = 25e16; // 25%
+
+    function setUp() public virtual {
+        // Start tests at a non-zero timestamp
+        vm.warp(block.timestamp + 600);
+
+        accounts = new Accounts();
+        createAccounts();
+
+        (A, B, C, D, E, F, G) = (
+            accountsList[0],
+            accountsList[1],
+            accountsList[2],
+            accountsList[3],
+            accountsList[4],
+            accountsList[5],
+            accountsList[6]
+        );
+
+        TestDeployer deployer = new TestDeployer();
+
+        // Create WETHTester first - this will be branch 0's collateral AND the gauge's staking token
+        WETHTester wethTester = new WETHTester(100 ether, 1 days);
+
+        // Create gauge1 with WETHTester as staking token (must match branch 0's collateral)
+        gauge1 = new AeroGaugeTester(address(wethTester), deployer.AERO_TOKEN_ADDRESS());
+        aeroToken = MockAeroToken(gauge1.rewardToken());
+        
+        // Deploy 3 branches: 1 Aero LP + 2 normal
+        // Note: For multi-gauge testing, we'd need to modify the deployer or use separate deployments
+        TestDeployer.TroveManagerParams[] memory troveManagerParamsArray = new TestDeployer.TroveManagerParams[](3);
+        
+        // Branch 0: Aero LP collateral (uses WETHTester as LP token)
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams({
+            CCR: 150e16,
+            MCR: 110e16,
+            BCR: 10e16,
+            SCR: 110e16,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 5e16,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 10e16,
+            isAeroLPCollateral: true,
+            aeroGaugeAddress: address(gauge1)
+        });
+        
+        // Branch 1: Normal collateral (for comparison testing)
+        troveManagerParamsArray[1] = TestDeployer.TroveManagerParams({
+            CCR: 160e16,
+            MCR: 120e16,
+            BCR: 10e16,
+            SCR: 120e16,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 5e16,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 10e16,
+            isAeroLPCollateral: false,
+            aeroGaugeAddress: address(0)
+        });
+        
+        // Branch 2: Normal collateral (for additional comparison)
+        troveManagerParamsArray[2] = TestDeployer.TroveManagerParams({
+            CCR: 150e16,
+            MCR: 110e16,
+            BCR: 10e16,
+            SCR: 110e16,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 5e16,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 10e16,
+            isAeroLPCollateral: false,
+            aeroGaugeAddress: address(0)
+        });
+
+        // Deploy contracts - pass our WETHTester so branch 0 uses it as collateral
+        TestDeployer.DeployAndConnectContractsResults memory result =
+            deployer.deployAndConnectContracts(troveManagerParamsArray, IWETH(address(wethTester)));
+
+        // Store branch references
+        aeroLPBranch1 = result.contractsArray[0];
+        aeroLPBranch2 = result.contractsArray[1];
+        normalBranch = result.contractsArray[2];
+        
+        // Store branches array
+        for (uint256 i = 0; i < result.contractsArray.length; i++) {
+            branches.push(result.contractsArray[i]);
+        }
+
+        // Store collateral tokens
+        lpToken1 = aeroLPBranch1.collToken;
+        lpToken2 = aeroLPBranch2.collToken;
+        normalCollToken = normalBranch.collToken;
+
+        // Create gauge2 with branch 1's collateral token (for future multi-gauge tests)
+        gauge2 = new AeroGaugeTester(address(lpToken2), address(aeroToken));
+
+        // Wire up core contracts
+        aeroManager = result.aeroManager;
+        collateralRegistry = result.collateralRegistry;
+        boldToken = result.boldToken;
+        hintHelpers = result.hintHelpers;
+        WETH = IWETH(address(wethTester));
+
+        // Give collateral to test accounts for all branches
+        uint256 initialCollAmount = 10_000_000e18;
+        for (uint256 i = 0; i < 6; i++) {
+            // Branch 0 (Aero LP 1) - lpToken1 IS WETH, so this also covers gas compensation
+            // We give extra for gas compensation since WETH is both collateral and gas comp
+            _giveAndApproveCollateral(lpToken1, accountsList[i], initialCollAmount + 100 ether, address(aeroLPBranch1.borrowerOperations));
+            // Branch 1
+            _giveAndApproveCollateral(lpToken2, accountsList[i], initialCollAmount, address(aeroLPBranch2.borrowerOperations));
+            // Branch 2
+            _giveAndApproveCollateral(normalCollToken, accountsList[i], initialCollAmount, address(normalBranch.borrowerOperations));
+            // Approve WETH for all branches (already dealt above via lpToken1)
+            vm.prank(accountsList[i]);
+            WETH.approve(address(aeroLPBranch1.borrowerOperations), type(uint256).max);
+            vm.prank(accountsList[i]);
+            WETH.approve(address(aeroLPBranch2.borrowerOperations), type(uint256).max);
+            vm.prank(accountsList[i]);
+            WETH.approve(address(normalBranch.borrowerOperations), type(uint256).max);
+        }
+    }
+
+    function _giveAndApproveCollateral(IERC20 _token, address _account, uint256 _amount, address _spender) internal {
+        deal(address(_token), _account, _amount);
+        vm.prank(_account);
+        _token.approve(_spender, _amount);
+    }
+
+    // ============ Helper Functions ============
+
+    function _boundColl(uint256 _coll) internal pure returns (uint256) {
+        return bound(_coll, MIN_COLL, MAX_COLL);
+    }
+
+    function _boundDebt(uint256 _debt) internal pure returns (uint256) {
+        return bound(_debt, MIN_DEBT_AMOUNT, MAX_DEBT);
+    }
+
+    function _boundInterestRate(uint256 _rate) internal pure returns (uint256) {
+        return bound(_rate, MIN_INTEREST_RATE, MAX_INTEREST_RATE);
+    }
+
+    function _openTroveOnBranch(
+        TestDeployer.LiquityContractsDev memory _branch,
+        address _account,
+        uint256 _index,
+        uint256 _coll,
+        uint256 _boldAmount,
+        uint256 _annualInterestRate
+    ) internal returns (uint256 troveId) {
+        uint256 upfrontFee = hintHelpers.predictOpenTroveUpfrontFee(
+            _getBranchIndex(_branch),
+            _boldAmount,
+            _annualInterestRate
+        );
+
+        vm.startPrank(_account);
+        troveId = _branch.borrowerOperations.openTrove(
+            _account,
+            _index,
+            _coll,
+            _boldAmount,
+            0, // _upperHint
+            0, // _lowerHint
+            _annualInterestRate,
+            upfrontFee,
+            address(0),
+            address(0),
+            address(0)
+        );
+        vm.stopPrank();
+    }
+
+    function _getBranchIndex(TestDeployer.LiquityContractsDev memory _branch) internal view returns (uint256) {
+        for (uint256 i = 0; i < branches.length; i++) {
+            if (address(branches[i].troveManager) == address(_branch.troveManager)) {
+                return i;
+            }
+        }
+        revert("Branch not found");
+    }
+
+    function _getAeroManager() internal view returns (AeroManager) {
+        return AeroManager(address(aeroManager));
+    }
+
+    // ============ Fuzz Tests ============
+
+    /**
+     * @notice Test opening a trove with Aero LP collateral stakes correctly in gauge
+     */
+    function testFuzz_openTroveWithAeroLPCollateral(
+        uint256 _coll,
+        uint256 _debt,
+        uint256 _interestRate
+    ) public {
+        _debt = _boundDebt(_debt);
+        _interestRate = _boundInterestRate(_interestRate);
+
+        // Calculate minimum collateral required for this debt, then bound _coll above it
+        // Use CCR (not MCR) because first trove needs to meet CCR, plus buffer for upfront fee
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 minColl = _debt * (ccr + 10e16) / price + 1e18; // CCR + 10% buffer for fees
+        _coll = bound(_coll, minColl, MAX_COLL);
+
+        uint256 gaugeBalanceBefore = gauge1.balanceOf(address(aeroManager));
+        uint256 stakedAmountsBefore = _getAeroManager().stakedAmounts(address(gauge1));
+
+        // Open trove on Aero LP branch
+        _openTroveOnBranch(aeroLPBranch1, A, 0, _coll, _debt, _interestRate);
+
+        // Verify collateral is staked in gauge
+        uint256 gaugeBalanceAfter = gauge1.balanceOf(address(aeroManager));
+        uint256 stakedAmountsAfter = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 activePoolBalance = aeroLPBranch1.activePool.getCollBalance();
+
+        assertEq(gaugeBalanceAfter - gaugeBalanceBefore, _coll, "Gauge balance should increase by coll amount");
+        assertEq(stakedAmountsAfter - stakedAmountsBefore, _coll, "Staked amounts should increase by coll amount");
+        assertEq(stakedAmountsAfter, activePoolBalance, "Staked amounts should equal ActivePool balance");
+        
+        // Verify no LP tokens stuck in ActivePool (all should be in gauge)
+        assertEq(lpToken1.balanceOf(address(aeroLPBranch1.activePool)), 0, "No LP tokens should be in ActivePool");
+    }
+
+    /**
+     * @notice Test that multiple users opening troves on the same Aero LP branch track collateral correctly
+     */
+    function testFuzz_multipleTrovesOnAeroLPBranch(
+        uint256 _coll1,
+        uint256 _coll2,
+        uint256 _debt
+    ) public {
+        _debt = _boundDebt(_debt);
+
+        // Use CCR + buffer for first trove (sets the TCR)
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 minColl = _debt * (ccr + 10e16) / price + 1e18;
+        _coll1 = bound(_coll1, minColl, MAX_COLL / 2);
+        _coll2 = bound(_coll2, minColl, MAX_COLL / 2);
+
+        uint256 interestRate = 5e16; // 5%
+
+        // Open first trove
+        _openTroveOnBranch(aeroLPBranch1, A, 0, _coll1, _debt, interestRate);
+
+        // Open second trove (different user)
+        _openTroveOnBranch(aeroLPBranch1, B, 0, _coll2, _debt, interestRate);
+
+        // Verify gauge tracks both collaterals
+        uint256 gaugeBalance = gauge1.balanceOf(address(aeroManager));
+        uint256 staked = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 expectedTotal = _coll1 + _coll2;
+
+        assertEq(gaugeBalance, expectedTotal, "Gauge should have both collaterals");
+        assertEq(staked, expectedTotal, "Staked should equal total collateral");
+        assertEq(staked, aeroLPBranch1.activePool.getCollBalance(), "Staked should match AP balance");
+    }
+
+    /**
+     * @notice Test adding collateral to existing trove updates gauge correctly
+     */
+    function testFuzz_adjustTroveAddCollateral(
+        uint256 _initialColl,
+        uint256 _addColl,
+        uint256 _debt
+    ) public {
+        _debt = _boundDebt(_debt);
+        _addColl = bound(_addColl, 1e17, MAX_COLL / 2);
+
+        // Ensure sufficient collateralization (use CCR + buffer for upfront fee)
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 minColl = _debt * (ccr + 10e16) / price + 1e18;
+        _initialColl = bound(_initialColl, minColl, MAX_COLL / 2);
+
+        uint256 interestRate = 5e16;
+
+        // Open trove
+        uint256 troveId = _openTroveOnBranch(aeroLPBranch1, A, 0, _initialColl, _debt, interestRate);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 gaugeBefore = gauge1.balanceOf(address(aeroManager));
+
+        // Add collateral
+        vm.startPrank(A);
+        aeroLPBranch1.borrowerOperations.addColl(troveId, _addColl);
+        vm.stopPrank();
+
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 gaugeAfter = gauge1.balanceOf(address(aeroManager));
+
+        assertEq(stakedAfter - stakedBefore, _addColl, "Staked should increase by added coll");
+        assertEq(gaugeAfter - gaugeBefore, _addColl, "Gauge balance should increase by added coll");
+        assertEq(stakedAfter, aeroLPBranch1.activePool.getCollBalance(), "Staked should match AP balance");
+    }
+
+    /**
+     * @notice Test withdrawing collateral from trove unstakes from gauge correctly
+     */
+    function testFuzz_adjustTroveWithdrawCollateral(
+        uint256 _initialColl,
+        uint256 _withdrawColl,
+        uint256 _debt
+    ) public {
+        _debt = _boundDebt(_debt);
+        
+        // Calculate collateral bounds
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 mcr = aeroLPBranch1.troveManager.get_MCR();
+        
+        // Open with enough collateral to allow meaningful withdrawal while staying above CCR
+        // Initial coll must be > CCR * debt / price (for opening) AND allow withdrawal
+        uint256 minCollForOpening = _debt * (ccr + 15e16) / price + 1e18; // CCR + 15% buffer
+        _initialColl = bound(_initialColl, minCollForOpening, MAX_COLL / 2);
+        
+        // First open a highly-collateralized trove for B to buffer TCR
+        uint256 safeCollB = _debt * (ccr + 50e16) / price; // CCR + 50% buffer for B
+        _openTroveOnBranch(aeroLPBranch1, B, 0, safeCollB, _debt, 5e16);
+        
+        // Open trove for A
+        uint256 troveId = _openTroveOnBranch(aeroLPBranch1, A, 0, _initialColl, _debt, 5e16);
+        
+        // Calculate safe withdrawal amount - A must stay above MCR, and TCR must stay above CCR
+        // With B's buffer, we can safely withdraw A down to MCR
+        uint256 minCollAfterWithdraw = _debt * (mcr + 5e16) / price;
+        uint256 maxWithdraw = _initialColl > minCollAfterWithdraw ? _initialColl - minCollAfterWithdraw : 0;
+        vm.assume(maxWithdraw >= 1e17);
+        _withdrawColl = bound(_withdrawColl, 1e17, maxWithdraw);
+
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 userBalanceBefore = lpToken1.balanceOf(A);
+
+        // Withdraw collateral
+        vm.prank(A);
+        aeroLPBranch1.borrowerOperations.withdrawColl(troveId, _withdrawColl);
+
+        // Verify unstaking
+        assertEq(stakedBefore - _getAeroManager().stakedAmounts(address(gauge1)), _withdrawColl, "Staked should decrease");
+        assertEq(lpToken1.balanceOf(A) - userBalanceBefore, _withdrawColl, "User should receive withdrawn coll");
+        assertEq(_getAeroManager().stakedAmounts(address(gauge1)), aeroLPBranch1.activePool.getCollBalance(), "Staked should match AP balance");
+    }
+
+    /**
+     * @notice Test closing trove fully unstakes from gauge
+     */
+    function testFuzz_closeTrove(uint256 _coll, uint256 _debt) public {
+        _debt = _boundDebt(_debt);
+
+        // Ensure sufficient collateralization (use CCR + buffer for upfront fee)
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 minColl = _debt * (ccr + 10e16) / price + 1e18;
+        _coll = bound(_coll, minColl, MAX_COLL / 2);
+
+        uint256 interestRate = 5e16;
+
+        // First open a trove for B so we can close A's trove (protocol requires at least 1 trove)
+        _openTroveOnBranch(aeroLPBranch1, B, 0, minColl, _debt, interestRate);
+
+        // Open trove for A
+        uint256 troveId = _openTroveOnBranch(aeroLPBranch1, A, 0, _coll, _debt, interestRate);
+
+        // Get A's actual trove collateral
+        uint256 troveCollA = aeroLPBranch1.troveManager.getLatestTroveData(troveId).entireColl;
+        
+        // Give A enough BOLD to repay debt (with buffer for any accrued interest)
+        deal(address(boldToken), A, aeroLPBranch1.troveManager.getTroveEntireDebt(troveId) * 2);
+
+        uint256 userCollBefore = lpToken1.balanceOf(A);
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge1));
+
+        // Close trove
+        vm.startPrank(A);
+        boldToken.approve(address(aeroLPBranch1.borrowerOperations), type(uint256).max);
+        aeroLPBranch1.borrowerOperations.closeTrove(troveId);
+        vm.stopPrank();
+
+        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 userCollAfter = lpToken1.balanceOf(A);
+
+        // After closing A's trove, the staked amount should decrease
+        // Note: User receives collateral minus gas compensation (ETH_GAS_COMPENSATION = 0.0375 ETH)
+        assertEq(stakedBefore - stakedAfter, troveCollA, "Staked should decrease by closed trove's collateral");
+        // User receives collateral minus gas compensation which is refunded
+        assertGt(userCollAfter, userCollBefore, "User should receive collateral back");
+        // The difference should be within gas compensation bounds (0.0375 ETH is the gas comp)
+        assertApproxEqAbs(userCollAfter - userCollBefore, troveCollA, 0.1 ether, "User should receive most collateral back");
+        // Gauge accounting invariant
+        assertEq(stakedAfter, aeroLPBranch1.activePool.getCollBalance(), "Staked should match AP balance");
+    }
+
+    /**
+     * @notice Test multiple stakes and unstakes maintain correct accounting
+     */
+    function testFuzz_multipleStakeUnstake(
+        uint256 _coll1,
+        uint256 _coll2,
+        uint256 _debt
+    ) public {
+        _debt = _boundDebt(_debt);
+
+        // Ensure sufficient collateralization for both troves (use CCR + buffer for upfront fee)
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 minColl = _debt * (ccr + 10e16) / price + 1e18;
+        _coll1 = bound(_coll1, minColl, MAX_COLL / 2);
+        _coll2 = bound(_coll2, minColl, MAX_COLL / 2);
+
+        uint256 interestRate = 5e16;
+
+        // User A opens trove
+        _openTroveOnBranch(aeroLPBranch1, A, 0, _coll1, _debt, interestRate);
+
+        // User B opens trove
+        _openTroveOnBranch(aeroLPBranch1, B, 0, _coll2, _debt, interestRate);
+
+        uint256 expectedStaked = _coll1 + _coll2;
+        uint256 actualStaked = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 gaugeBalance = gauge1.balanceOf(address(aeroManager));
+
+        assertEq(actualStaked, expectedStaked, "Total staked should be sum of both collaterals");
+        assertEq(gaugeBalance, expectedStaked, "Gauge balance should match total staked");
+        assertEq(actualStaked, aeroLPBranch1.activePool.getCollBalance(), "Staked should match AP balance");
+
+        // User A closes trove
+        uint256 troveDebtA = aeroLPBranch1.troveManager.getTroveEntireDebt(
+            uint256(keccak256(abi.encode(A, A, 0)))
+        );
+        deal(address(boldToken), A, troveDebtA);
+        
+        vm.startPrank(A);
+        boldToken.approve(address(aeroLPBranch1.borrowerOperations), troveDebtA);
+        aeroLPBranch1.borrowerOperations.closeTrove(uint256(keccak256(abi.encode(A, A, 0))));
+        vm.stopPrank();
+
+        uint256 stakedAfterAClose = _getAeroManager().stakedAmounts(address(gauge1));
+        assertEq(stakedAfterAClose, _coll2, "After A closes, only B's collateral should remain");
+    }
+
+    /**
+     * @notice Test claiming and distributing AERO rewards
+     */
+    function testFuzz_claimAndDistributeRewards(uint256 _coll, uint256 _debt) public {
+        _debt = _boundDebt(_debt);
+
+        // Ensure sufficient collateralization (use CCR + buffer for upfront fee)
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 minColl = _debt * (ccr + 10e16) / price + 1e18;
+        _coll = bound(_coll, minColl, MAX_COLL);
+
+        uint256 interestRate = 5e16;
+
+        // Open trove to have collateral staked
+        _openTroveOnBranch(aeroLPBranch1, A, 0, _coll, _debt, interestRate);
+
+        AeroManager am = _getAeroManager();
+        address governor = am.governor();
+        address treasury = am.treasuryAddress();
+
+        uint256 treasuryBalanceBefore = aeroToken.balanceOf(treasury);
+
+        // Claim rewards
+        am.claim(address(gauge1));
+
+        // The mock gauge mints rewards equal to staked balance
+        uint256 expectedReward = _coll;
+        uint256 claimFee = expectedReward * am.claimFee() / 1e18;
+        uint256 netReward = expectedReward - claimFee;
+
+        uint256 treasuryBalanceAfter = aeroToken.balanceOf(treasury);
+        uint256 managerAeroBalance = aeroToken.balanceOf(address(am));
+
+        assertEq(treasuryBalanceAfter - treasuryBalanceBefore, claimFee, "Treasury should receive claim fee");
+        assertEq(managerAeroBalance, netReward, "Manager should hold net rewards");
+        assertEq(am.claimedAero(), netReward, "claimedAero should track net rewards");
+        assertEq(am.claimedAeroPerEpoch(0, address(gauge1)), netReward, "Epoch rewards should be tracked");
+
+        // Distribute rewards
+        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
+        recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: netReward});
+
+        vm.prank(governor);
+        am.distributeAero(address(gauge1), recipients);
+
+        assertEq(am.currentEpochs(address(gauge1)), 1, "Epoch should increment");
+        assertEq(am.claimableRewards(A), netReward, "User should have claimable rewards");
+
+        // User claims rewards
+        uint256 userAeroBefore = aeroToken.balanceOf(A);
+        am.claimRewards(A);
+        uint256 userAeroAfter = aeroToken.balanceOf(A);
+
+        assertEq(userAeroAfter - userAeroBefore, netReward, "User should receive rewards");
+        assertEq(am.claimableRewards(A), 0, "Claimable should be zeroed");
+    }
+
+    // ============ Edge Case Tests ============
+
+    /**
+     * @notice Test that zero collateral operations are handled correctly
+     */
+    function test_zeroCollateralOperations() public {
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 debt = 50_000e18;
+        uint256 coll = debt * (ccr + 10e16) / price + 1e18;
+
+        // First open a trove normally
+        _openTroveOnBranch(aeroLPBranch1, A, 0, coll, debt, 5e16);
+        uint256 troveId = uint256(keccak256(abi.encode(A, A, 0)));
+
+        // Try to add zero collateral - should either revert or be a no-op
+        uint256 stakedBefore = _getAeroManager().stakedAmounts(address(gauge1));
+        vm.startPrank(A);
+        try aeroLPBranch1.borrowerOperations.addColl(troveId, 0) {
+            // If it doesn't revert, staked amount should be unchanged
+            uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge1));
+            assertEq(stakedAfter, stakedBefore, "Zero add should not change staked");
+        } catch {
+            // Expected to revert for zero amount
+            assertTrue(true, "Zero add correctly reverted");
+        }
+        vm.stopPrank();
+    }
+
+    /**
+     * @notice Test concurrent operations from same user on same branch
+     */
+    function test_concurrentOperationsSameUser() public {
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 debt = 50_000e18;
+        uint256 coll = debt * (ccr + 10e16) / price + 1e18;
+
+        // Open first trove
+        uint256 troveId1 = _openTroveOnBranch(aeroLPBranch1, A, 0, coll, debt, 5e16);
+        
+        // For second trove, we need extra collateral + gas comp
+        // Since lpToken1 IS WETH, deal enough for both collateral and gas comp
+        deal(address(lpToken1), A, coll + 1 ether);
+        vm.prank(A);
+        lpToken1.approve(address(aeroLPBranch1.borrowerOperations), type(uint256).max);
+        vm.prank(A);
+        WETH.approve(address(aeroLPBranch1.borrowerOperations), type(uint256).max);
+        
+        uint256 upfrontFee2 = hintHelpers.predictOpenTroveUpfrontFee(0, debt, 6e16);
+        vm.prank(A);
+        uint256 troveId2 = aeroLPBranch1.borrowerOperations.openTrove(
+            A, 1, coll, debt, 0, 0, 6e16, upfrontFee2, address(0), address(0), address(0)
+        );
+
+        // Verify both troves exist
+        assertTrue(aeroLPBranch1.troveNFT.ownerOf(troveId1) == A, "A should own trove1");
+        assertTrue(aeroLPBranch1.troveNFT.ownerOf(troveId2) == A, "A should own trove2");
+
+        // Verify total staked is sum of both
+        uint256 totalExpected = coll * 2;
+        assertApproxEqRel(
+            _getAeroManager().stakedAmounts(address(gauge1)),
+            totalExpected,
+            0.01e18, // 1% tolerance for fees
+            "Total staked should be sum of both troves"
+        );
+    }
+
+    /**
+     * @notice Test that gauge accounting is correct after multiple operations
+     */
+    function testFuzz_gaugeAccountingAfterManyOperations(
+        uint256 numOperations,
+        uint256 seed
+    ) public {
+        numOperations = bound(numOperations, 1, 5);
+        
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 debt = 50_000e18;
+        uint256 coll = debt * (ccr + 10e16) / price + 1e18;
+
+        // Open initial trove for B (so we can close A's trove)
+        _openTroveOnBranch(aeroLPBranch1, B, 0, coll * 2, debt, 5e16);
+
+        // Open trove for A
+        _openTroveOnBranch(aeroLPBranch1, A, 0, coll, debt, 5e16);
+        uint256 troveId = uint256(keccak256(abi.encode(A, A, 0)));
+
+        // Perform random operations
+        // Note: try-catch is intentional here - operations may fail legitimately 
+        // (e.g., withdrawal violating ICR). The test verifies accounting invariants
+        // hold regardless of which operations succeed or fail.
+        for (uint256 i = 0; i < numOperations; i++) {
+            uint256 op = uint256(keccak256(abi.encode(seed, i))) % 2;
+            uint256 amount = bound(uint256(keccak256(abi.encode(seed, i, "amount"))), 1e17, 10e18);
+
+            if (op == 0) {
+                // Add collateral
+                _giveAndApproveCollateral(lpToken1, A, amount, address(aeroLPBranch1.borrowerOperations));
+                vm.prank(A);
+                try aeroLPBranch1.borrowerOperations.addColl(troveId, amount) {} catch {}
+            } else {
+                // Withdraw collateral (if possible)
+                vm.prank(A);
+                try aeroLPBranch1.borrowerOperations.withdrawColl(troveId, amount) {} catch {}
+            }
+        }
+
+        // Verify accounting invariant
+        uint256 staked = _getAeroManager().stakedAmounts(address(gauge1));
+        uint256 apBalance = aeroLPBranch1.activePool.getCollBalance();
+        uint256 gaugeBalance = gauge1.balanceOf(address(aeroManager));
+
+        assertEq(staked, apBalance, "Staked should match AP balance");
+        assertEq(gaugeBalance, staked, "Gauge balance should match staked");
+    }
+
+    /**
+     * @notice Test claim fee limits
+     */
+    function test_claimFeeWithinLimits() public view {
+        AeroManager am = _getAeroManager();
+        
+        // MAX_AERO_MANAGER_FEE = 50 * _1pct = 50e16 (50%)
+        uint256 maxFee = 50e16;
+        uint256 currentFee = am.claimFee();
+        
+        assertTrue(currentFee <= maxFee, "Claim fee should be within limits");
+    }
+
+    /**
+     * @notice Test that rewards are tracked per epoch correctly
+     */
+    function test_rewardsPerEpochTracking() public {
+        uint256 price = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch1.troveManager.get_CCR();
+        uint256 debt = 50_000e18;
+        uint256 coll = debt * (ccr + 10e16) / price + 1e18;
+
+        // Open trove
+        _openTroveOnBranch(aeroLPBranch1, A, 0, coll, debt, 5e16);
+
+        AeroManager am = _getAeroManager();
+        address governor = am.governor();
+
+        uint256 previousEpoch = am.currentEpochs(address(gauge1));
+
+        // Claim rewards (mock gauge gives rewards once based on balance)
+        am.claim(address(gauge1));
+        uint256 claimed = am.claimedAero();
+        
+        assertTrue(claimed > 0, "Should have claimed some rewards");
+
+        // Distribute to A
+        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
+        recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: claimed});
+
+        vm.prank(governor);
+        am.distributeAero(address(gauge1), recipients);
+
+        // Verify epoch incremented
+        uint256 currentEpoch = am.currentEpochs(address(gauge1));
+        assertEq(currentEpoch, previousEpoch + 1, "Epoch should increment");
+
+        // Verify claimable rewards set correctly
+        assertEq(am.claimableRewards(A), claimed, "User should have claimable rewards");
+
+        // User claims rewards
+        uint256 balanceBefore = aeroToken.balanceOf(A);
+        am.claimRewards(A);
+        uint256 balanceAfter = aeroToken.balanceOf(A);
+        
+        assertEq(balanceAfter - balanceBefore, claimed, "User should receive rewards");
+        assertEq(am.claimableRewards(A), 0, "Claimable should be zeroed");
+    }
+
+    /**
+     * @notice Test normal branch behavior is identical for non-staking operations
+     */
+    function test_normalBranchBehaviorParity() public {
+        uint256 debt = 50_000e18;
+        uint256 interestRate = 5e16;
+        
+        // Get prices and CCRs
+        uint256 price1 = aeroLPBranch1.priceFeed.getPrice();
+        uint256 ccr1 = aeroLPBranch1.troveManager.get_CCR();
+        uint256 coll1 = debt * (ccr1 + 10e16) / price1 + 1e18;
+
+        uint256 price2 = aeroLPBranch2.priceFeed.getPrice();
+        uint256 ccr2 = aeroLPBranch2.troveManager.get_CCR();
+        uint256 coll2 = debt * (ccr2 + 10e16) / price2 + 1e18;
+
+        // Open troves on both branches
+        uint256 troveId1 = _openTroveOnBranch(aeroLPBranch1, A, 0, coll1, debt, interestRate);
+        uint256 troveId2 = _openTroveOnBranch(aeroLPBranch2, B, 0, coll2, debt, interestRate);
+
+        // Warp time
+        vm.warp(block.timestamp + 30 days);
+
+        // Both should accrue interest similarly
+        uint256 debt1After = aeroLPBranch1.troveManager.getTroveEntireDebt(troveId1);
+        uint256 debt2After = aeroLPBranch2.troveManager.getTroveEntireDebt(troveId2);
+
+        assertTrue(debt1After > debt, "Branch 1 should accrue interest");
+        assertTrue(debt2After > debt, "Branch 2 should accrue interest");
+    }
+}

--- a/contracts/test/AeroLPInvariants.t.sol
+++ b/contracts/test/AeroLPInvariants.t.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
+import {Math} from "openzeppelin-contracts/contracts/utils/math/Math.sol";
+import {BatchId} from "src/Types/BatchId.sol";
+import {LatestBatchData} from "src/Types/LatestBatchData.sol";
+import {LatestTroveData} from "src/Types/LatestTroveData.sol";
+import {ISortedTroves} from "src/Interfaces/ISortedTroves.sol";
+import {IStabilityPool} from "src/Interfaces/IStabilityPool.sol";
+import {ITroveManager} from "src/Interfaces/ITroveManager.sol";
+import {IWETH} from "src/Interfaces/IWETH.sol";
+import {AeroManager} from "src/AeroManager.sol";
+import {Logging} from "./Utils/Logging.sol";
+import {StringFormatting} from "./Utils/StringFormatting.sol";
+import {ITroveManagerTester} from "./TestContracts/Interfaces/ITroveManagerTester.sol";
+import {Assertions} from "./TestContracts/Assertions.sol";
+import {BaseInvariantTest} from "./TestContracts/BaseInvariantTest.sol";
+import {BaseMultiCollateralTest} from "./TestContracts/BaseMultiCollateralTest.sol";
+import {TestDeployer} from "./TestContracts/Deployment.t.sol";
+import {AeroLPInvariantsTestHandler} from "./TestContracts/AeroLPInvariantsTestHandler.t.sol";
+import {AeroGaugeTester, MockAeroToken} from "./TestContracts/AeroGaugeTester.sol";
+import {WETHTester} from "./TestContracts/WETHTester.sol";
+
+/**
+ * @title AeroLPInvariants
+ * @notice Invariant tests for Aero LP collateral
+ * @dev Extends InvariantsTestHandler with Aero LP-specific invariants.
+ *      Tests all standard protocol invariants PLUS Aero LP-specific:
+ *      - Collateral staking accounting
+ *      - Gauge balance consistency
+ *      - AeroManager state tracking
+ */
+contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCollateralTest {
+    using Strings for uint256;
+    using StringFormatting for uint256;
+
+    // Aero LP specific
+    AeroGaugeTester internal gauge;
+    MockAeroToken internal aeroToken;
+    
+    // Handler (inherits from InvariantsTestHandler)
+    AeroLPInvariantsTestHandler handler;
+
+    // Constants
+    uint256 constant AERO_LP_BRANCH_INDEX = 0;
+
+    function setUp() public override {
+        super.setUp();
+
+        // Start tests at a non-zero timestamp
+        vm.warp(block.timestamp + 600);
+
+        TestDeployer deployer = new TestDeployer();
+
+        // Create WETHTester first - this will be branch 0's collateral (Aero LP)
+        WETHTester wethTester = new WETHTester(100 ether, 1 days);
+
+        // Create gauge with WETHTester as staking token
+        gauge = new AeroGaugeTester(address(wethTester), deployer.AERO_TOKEN_ADDRESS());
+        aeroToken = MockAeroToken(gauge.rewardToken());
+
+        // Deploy branches: Aero LP + normal branches
+        uint256 numBranches = 2;
+        TestDeployer.TroveManagerParams[] memory p = new TestDeployer.TroveManagerParams[](numBranches);
+
+        // Branch 0: Aero LP collateral
+        p[0] = TestDeployer.TroveManagerParams({
+            CCR: 1.5 ether,
+            MCR: 1.1 ether,
+            BCR: 0.1 ether,
+            SCR: 1.1 ether,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 0.05 ether,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 0.1 ether,
+            isAeroLPCollateral: true,
+            aeroGaugeAddress: address(gauge)
+        });
+
+        // Branch 1: Normal collateral
+        p[1] = TestDeployer.TroveManagerParams({
+            CCR: 1.5 ether,
+            MCR: 1.1 ether,
+            BCR: 0.1 ether,
+            SCR: 1.1 ether,
+            debtLimit: 100_000_000 ether,
+            LIQUIDATION_PENALTY_SP: 0.05 ether,
+            LIQUIDATION_PENALTY_REDISTRIBUTION: 0.1 ether,
+            isAeroLPCollateral: false,
+            aeroGaugeAddress: address(0)
+        });
+
+        // Deploy contracts using the deployer that accepts WETH
+        TestDeployer.DeployAndConnectContractsResults memory result =
+            deployer.deployAndConnectContracts(p, IWETH(address(wethTester)));
+
+        // Setup contracts struct for handler and base test
+        Contracts memory contracts;
+        contracts.branches = result.contractsArray;
+        contracts.aeroManager = result.aeroManager;
+        contracts.collateralRegistry = result.collateralRegistry;
+        contracts.boldToken = result.boldToken;
+        contracts.hintHelpers = result.hintHelpers;
+        contracts.weth = IWETH(address(wethTester));
+        setupContracts(contracts);
+
+        // Create handler with Aero LP support (inherits all InvariantsTestHandler functionality)
+        handler = new AeroLPInvariantsTestHandler({
+            contracts: contracts,
+            assumeNoExpectedFailures: true,
+            _gauge: address(gauge),
+            _aeroLPBranchIndex: AERO_LP_BRANCH_INDEX
+        });
+        vm.label(address(handler), "handler");
+        targetContract(address(handler));
+    }
+
+    // ============ Standard Protocol Invariants (from InvariantsTestHandler) ============
+
+    /**
+     * @notice Actors should have empty wallets before handler calls
+     */
+    function invariant_FundsAreSwept() external view {
+        for (uint256 i = 0; i < actors.length; ++i) {
+            address actor = actors[i].account;
+
+            assertEqDecimal(boldToken.balanceOf(actor), 0, 18, "Incomplete BOLD sweep");
+            assertEqDecimal(weth.balanceOf(actor), 0, 18, "Incomplete WETH sweep");
+
+            for (uint256 j = 0; j < branches.length; ++j) {
+                IERC20 collToken = branches[j].collToken;
+                address borrowerOperations = address(branches[j].borrowerOperations);
+
+                assertEqDecimal(weth.allowance(actor, borrowerOperations), 0, 18, "WETH allowance != 0");
+                assertEqDecimal(collToken.balanceOf(actor), 0, 18, "Incomplete coll sweep");
+                assertEqDecimal(collToken.allowance(actor, borrowerOperations), 0, 18, "Coll allowance != 0");
+            }
+        }
+    }
+
+    /**
+     * @notice System state should match ghost state from handler
+     */
+    function invariant_SystemStateMatchesGhostState() external view {
+        for (uint256 i = 0; i < branches.length; ++i) {
+            TestDeployer.LiquityContractsDev memory c = branches[i];
+
+            assertEq(c.troveManager.getTroveIdsCount(), handler.numTroves(i), "Wrong number of Troves");
+            assertEq(c.troveManager.lastZombieTroveId(), handler.designatedVictimId(i), "Wrong designated victim");
+            assertEq(c.sortedTroves.getSize(), handler.numTroves(i) - handler.numZombies(i), "Wrong SortedTroves size");
+        }
+    }
+
+    // ============ Aero LP-Specific Invariants ============
+
+    /**
+     * @notice AeroManager stakedAmounts should equal ActivePool collateral balance
+     * @dev For Aero LP branches, all collateral is staked in the gauge via AeroManager
+     */
+    function invariant_StakedEqualsCollBalance() external view {
+        uint256 stakedAmount = handler.getStakedAmount(address(gauge));
+        uint256 activePoolBalance = handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX);
+
+        assertEq(
+            stakedAmount,
+            activePoolBalance,
+            "Aero LP: stakedAmounts should equal ActivePool collateral balance"
+        );
+    }
+
+    /**
+     * @notice Gauge balance should equal AeroManager stakedAmounts
+     * @dev The gauge should hold exactly what AeroManager says is staked
+     */
+    function invariant_GaugeBalanceEqualsStaked() external view {
+        uint256 stakedAmount = handler.getStakedAmount(address(gauge));
+        uint256 gaugeBalance = handler.getGaugeBalance(address(gauge));
+
+        assertEq(
+            gaugeBalance,
+            stakedAmount,
+            "Aero LP: gauge balance should equal stakedAmounts"
+        );
+    }
+
+    /**
+     * @notice No LP tokens should be stuck in ActivePool for Aero LP branches
+     * @dev All collateral should be in the gauge, not in ActivePool directly
+     */
+    function invariant_NoLPTokensInActivePool() external view {
+        uint256 activePoolTokenBalance = handler.getCollTokenInActivePool(AERO_LP_BRANCH_INDEX);
+
+        assertEq(
+            activePoolTokenBalance,
+            0,
+            "Aero LP: No LP tokens should be directly in ActivePool"
+        );
+    }
+
+    /**
+     * @notice Aero LP branch should be registered as such
+     */
+    function invariant_AeroLPBranchRegistered() external view {
+        bool isAeroLP = handler.isActivePoolAeroLP(AERO_LP_BRANCH_INDEX);
+        assertTrue(isAeroLP, "Branch 0 should be Aero LP collateral");
+    }
+
+    /**
+     * @notice Normal branches should NOT be registered as Aero LP
+     */
+    function invariant_NormalBranchNotAeroLP() external view {
+        for (uint256 i = 1; i < branches.length; i++) {
+            bool isAeroLP = handler.isActivePoolAeroLP(i);
+            assertFalse(isAeroLP, string.concat("Branch ", i.toString(), " should NOT be Aero LP collateral"));
+        }
+    }
+
+    /**
+     * @notice Total system collateral accounting for Aero LP branch
+     * @dev Staked amount should equal active pool balance
+     */
+    function invariant_AeroLPCollateralAccounting() external view {
+        uint256 stakedAmount = handler.getStakedAmount(address(gauge));
+        uint256 activePoolColl = handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX);
+        uint256 gaugeBalance = handler.getGaugeBalance(address(gauge));
+
+        // Core accounting invariants
+        assertEq(stakedAmount, activePoolColl, "Aero LP: Staked should match ActivePool");
+        assertEq(gaugeBalance, stakedAmount, "Aero LP: Gauge should hold staked amount");
+    }
+
+    // ============ Debug/Logging Invariant ============
+
+    /**
+     * @notice Log current state (always passes)
+     */
+    function invariant_callSummary() external {
+        emit log_named_uint("Aero LP branch troves", handler.numTroves(AERO_LP_BRANCH_INDEX));
+        emit log_named_uint("Staked amount", handler.getStakedAmount(address(gauge)));
+        emit log_named_uint("Gauge balance", handler.getGaugeBalance(address(gauge)));
+        emit log_named_uint("ActivePool balance", handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX));
+    }
+}

--- a/contracts/test/TestContracts/AeroLPInvariantsTestHandler.t.sol
+++ b/contracts/test/TestContracts/AeroLPInvariantsTestHandler.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
+import {AeroManager} from "src/AeroManager.sol";
+import {IAeroManager} from "src/Interfaces/IAeroManager.sol";
+import {InvariantsTestHandler} from "./InvariantsTestHandler.t.sol";
+import {BaseMultiCollateralTest} from "./BaseMultiCollateralTest.sol";
+import {TestDeployer} from "./Deployment.t.sol";
+import {StringFormatting} from "../Utils/StringFormatting.sol";
+
+/**
+ * @title AeroLPInvariantsTestHandler
+ * @notice Handler for Aero LP invariant testing that extends InvariantsTestHandler
+ * @dev Inherits all the rigorous testing from InvariantsTestHandler (trove operations,
+ *      batch management, liquidations, redemptions, SP operations, etc.) and adds 
+ *      Aero LP-specific state tracking and view functions for invariant checks
+ */
+contract AeroLPInvariantsTestHandler is InvariantsTestHandler {
+    using Strings for uint256;
+    using StringFormatting for *;
+
+    // ============ Aero LP-Specific State ============
+    
+    /// @notice Track if a branch is an Aero LP branch
+    mapping(uint256 branchIndex => bool) public isAeroLPBranch;
+    
+    /// @notice Track gauge address per branch
+    mapping(uint256 branchIndex => address) public branchGauge;
+    
+    /// @notice Index of the primary Aero LP branch
+    uint256 public aeroLPBranchIndex;
+    
+    /// @notice Gauge address for the primary Aero LP branch
+    address public gauge;
+
+    // ============ Constructor ============
+    
+    constructor(
+        Contracts memory contracts,
+        bool assumeNoExpectedFailures,
+        address _gauge,
+        uint256 _aeroLPBranchIndex
+    ) InvariantsTestHandler(contracts, assumeNoExpectedFailures) {
+        gauge = _gauge;
+        aeroLPBranchIndex = _aeroLPBranchIndex;
+        
+        // Initialize Aero LP branch tracking
+        for (uint256 i = 0; i < branches.length; i++) {
+            bool isAeroLP = branches[i].activePool.isAeroLPCollateral();
+            isAeroLPBranch[i] = isAeroLP;
+            if (isAeroLP) {
+                branchGauge[i] = _gauge;
+            }
+        }
+    }
+
+    // ============ Aero LP-Specific View Functions for Invariant Checks ============
+    
+    /**
+     * @notice Get the actual staked amount from AeroManager for a gauge
+     */
+    function getStakedAmount(address _gauge) external view returns (uint256) {
+        return AeroManager(address(aeroManager)).stakedAmounts(_gauge);
+    }
+    
+    /**
+     * @notice Get the gauge balance held by AeroManager
+     */
+    function getGaugeBalance(address _gauge) external view returns (uint256) {
+        return IERC20(_gauge).balanceOf(address(aeroManager));
+    }
+    
+    /**
+     * @notice Get ActivePool collateral balance for a branch
+     */
+    function getActivePoolCollBalance(uint256 branchIdx) external view returns (uint256) {
+        return branches[branchIdx].activePool.getCollBalance();
+    }
+    
+    /**
+     * @notice Get collateral token balance directly in ActivePool (should be 0 for Aero LP)
+     */
+    function getCollTokenInActivePool(uint256 branchIdx) external view returns (uint256) {
+        return branches[branchIdx].collToken.balanceOf(address(branches[branchIdx].activePool));
+    }
+
+    /**
+     * @notice Check if a branch's ActivePool is registered as Aero LP collateral
+     */
+    function isActivePoolAeroLP(uint256 branchIdx) external view returns (bool) {
+        return branches[branchIdx].activePool.isAeroLPCollateral();
+    }
+
+    /**
+     * @notice Get the total collateral in default pool for a branch
+     */
+    function getDefaultPoolCollBalance(uint256 branchIdx) external view returns (uint256) {
+        return branches[branchIdx].pools.defaultPool.getCollBalance();
+    }
+
+    /**
+     * @notice Get the AeroManager address
+     */
+    function getAeroManagerAddress() external view returns (address) {
+        return address(aeroManager);
+    }
+
+    /**
+     * @notice Get number of Aero LP branches
+     */
+    function getNumAeroLPBranches() external view returns (uint256 count) {
+        for (uint256 i = 0; i < branches.length; i++) {
+            if (isAeroLPBranch[i]) count++;
+        }
+    }
+
+    /**
+     * @notice Get total collateral across all troves on a branch (from ghost state)
+     * @dev This uses the inherited getTrove function from InvariantsTestHandler
+     */
+    function getTotalTroveCollateral(uint256 branchIdx) external view returns (uint256 totalColl) {
+        uint256 n = numTroves(branchIdx);
+        for (uint256 j = 0; j < n; ++j) {
+            // getTrove returns: troveId, coll, debt, status, batchManager, totalCollRedist_, totalDebtRedist_
+            (, uint256 coll,,,,,) = this.getTrove(branchIdx, j);
+            totalColl += coll;
+        }
+    }
+}


### PR DESCRIPTION
closes #57 

Found and fixed a bug in `ActivePool.sendCollToDefaultPool()` uncovered from these new tests. LP token needs to be withdrawn from gauge before sending to DefaultPool.