### PR TITLE
Change backend query and rewards calculation per gauge

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,18 +3,18 @@ import { AeroEventsService } from "./services/aero-events.js";
 import { CollateralTrackerService } from "./services/collateral-tracker.js";
 import { RewardsCalculatorService } from "./services/rewards-calculator.js";
 import { TroveQueryService } from "./services/trove-query.js";
-import type { DistributionPeriod, DistributionResult } from "./types.js";
+import type { GaugeDistributionInfo, GaugeDistributionResult } from "./types.js";
 
 /**
  * Main distribution calculation flow.
  *
  * This function orchestrates the entire AERO rewards distribution calculation:
- * 1. Fetches Aero LP collateral tokens from Staked events
- * 2. Queries troves that were active during the distribution period
+ * 1. Gets per-gauge distribution info based on epoch data from distributed events
+ * 2. For each gauge: queries troves active during the gauge's period
  * 3. Calculates time-weighted average collateral for each trove
- * 4. Calculates reward distribution (placeholder - to be implemented)
+ * 4. Distributes rewards per gauge based on claim events at epoch = latestDistributedEpoch + 1
  */
-async function calculateDistribution(periodOverride?: DistributionPeriod): Promise<DistributionResult> {
+async function calculateDistribution(gaugeInfoOverride?: GaugeDistributionInfo[]): Promise<GaugeDistributionResult[]> {
   const config = loadConfig();
 
   // Initialize services
@@ -25,88 +25,79 @@ async function calculateDistribution(periodOverride?: DistributionPeriod): Promi
 
   console.log("Starting AERO rewards distribution calculation...");
 
-  // Step 1: Get the distribution period
+  // Step 1: Get current timestamp and per-gauge distribution info
   const currentTimestamp = await aeroEventsService.getCurrentBlockTimestamp();
-  const period: DistributionPeriod = periodOverride ?? {
-    startTimestamp: currentTimestamp - config.distributionPeriodSeconds,
-    endTimestamp: currentTimestamp,
-  };
+  console.log(`Current timestamp: ${currentTimestamp}`);
 
-  console.log(`Distribution period: ${period.startTimestamp} - ${period.endTimestamp}`);
+  const gaugeDistributionInfos =
+    gaugeInfoOverride ?? (await aeroEventsService.getGaugeDistributionInfo(currentTimestamp));
 
-  // Step 2: Get Aero LP collaterals from Staked events
-  console.log("Fetching Aero LP collaterals from Staked events...");
-  const lpCollaterals = await aeroEventsService.getAeroLPCollaterals();
-  console.log(`Found ${lpCollaterals.length} Aero LP collateral(s)`);
-
-  if (lpCollaterals.length === 0) {
-    console.log("No Aero LP collaterals found. Exiting.");
-    return {
-      period,
-      lpCollaterals: [],
-      totalClaimedAero: 0n,
-      distributions: [],
-    };
+  if (gaugeDistributionInfos.length === 0) {
+    console.log("No gauge distribution info found. Exiting.");
+    return [];
   }
 
-  // Step 3: Get collateral IDs for the LP tokens
-  console.log("Mapping LP tokens to collateral IDs...");
-  const tokenAddresses = lpCollaterals.map((lp) => lp.token);
-  const collateralIds = await troveQueryService.getCollateralIdsForTokens(tokenAddresses);
-  console.log(`Mapped to ${collateralIds.length} collateral ID(s): ${collateralIds.join(", ")}`);
+  console.log(`Found ${gaugeDistributionInfos.length} gauge(s) with distribution info`);
 
-  if (collateralIds.length === 0) {
-    console.log("No matching collateral IDs found. Exiting.");
-    return {
-      period,
-      lpCollaterals,
-      totalClaimedAero: 0n,
-      distributions: [],
-    };
+  // Log gauge info
+  for (const g of gaugeDistributionInfos) {
+    console.log(
+      `Gauge ${g.gauge}: period ${g.period.startTimestamp}-${g.period.endTimestamp}, ` +
+        `epoch ${g.latestDistributedEpoch} -> claim epoch ${g.claimEpoch}, rewards ${g.totalRewards}`,
+    );
   }
 
-  // Step 4: Query troves active during the period
-  console.log("Querying troves active during the distribution period...");
-  const troves = await troveQueryService.getTrovesActiveInPeriod(collateralIds, period);
-  console.log(`Found ${troves.length} trove(s) active during the period`);
+  // Step 2: Process each gauge separately and build per-gauge results
+  const results: GaugeDistributionResult[] = [];
 
-  if (troves.length === 0) {
-    console.log("No active troves found. Exiting.");
-    return {
-      period,
-      lpCollaterals,
-      totalClaimedAero: 0n,
-      distributions: [],
-    };
+  for (const gaugeInfo of gaugeDistributionInfos) {
+    console.log(`\nProcessing gauge ${gaugeInfo.gauge}...`);
+
+    // Get collateral ID for this gauge's LP token
+    const collateralIds = await troveQueryService.getCollateralIdsForTokens([gaugeInfo.token]);
+    if (collateralIds.length === 0) {
+      console.log(`  No collateral ID found for token ${gaugeInfo.token}. Skipping.`);
+      continue;
+    }
+    console.log(`  Collateral ID: ${collateralIds[0]}`);
+
+    // Query troves active during this gauge's period
+    const troves = await troveQueryService.getTrovesActiveInPeriod(collateralIds, gaugeInfo.period);
+    console.log(`  Found ${troves.length} trove(s) active during the period`);
+
+    if (troves.length === 0) {
+      console.log("  No active troves. Skipping.");
+      continue;
+    }
+
+    // Calculate TWA for troves in this gauge's period
+    const twaResults = await collateralTrackerService.calculateTWAForTroves(troves, gaugeInfo.period);
+    console.log(`  Calculated TWA for ${twaResults.length} trove(s)`);
+
+    // Calculate reward distributions for this gauge
+    const distributions = rewardsCalculatorService.calculateRewards(twaResults, gaugeInfo.totalRewards);
+    console.log(`  Generated distributions for ${distributions.length} trove(s), total rewards: ${gaugeInfo.totalRewards}`);
+
+    // Build per-gauge result
+    results.push({
+      gauge: gaugeInfo.gauge,
+      token: gaugeInfo.token,
+      period: gaugeInfo.period,
+      latestDistributedEpoch: gaugeInfo.latestDistributedEpoch,
+      claimEpoch: gaugeInfo.claimEpoch,
+      totalRewards: gaugeInfo.totalRewards,
+      distributions,
+    });
   }
-
-  // Step 5: Calculate time-weighted average collateral for each trove
-  console.log("Calculating time-weighted average collateral...");
-  const twaResults = await collateralTrackerService.calculateTWAForTroves(troves, period);
-  console.log(`Calculated TWA for ${twaResults.length} trove(s)`);
-
-  // Step 6: Get total claimed AERO for the period
-  console.log("Fetching total claimed AERO for the period...");
-  const totalClaimedAero = await aeroEventsService.getTotalClaimedInPeriod(period);
-  console.log(`Total claimed AERO (excluding fees): ${totalClaimedAero}`);
-
-  // Step 7: Calculate reward distributions
-  console.log("Calculating reward distributions...");
-  const distributions = rewardsCalculatorService.calculateRewards(twaResults, totalClaimedAero);
-  console.log(`Generated distributions for ${distributions.length} trove(s)`);
-
-  // Build final result
-  const result = rewardsCalculatorService.buildDistributionResult(distributions, {
-    period,
-    lpCollaterals,
-    totalClaimedAero,
-  });
 
   console.log("\nDistribution calculation complete!");
-  console.log(`Total troves: ${result.distributions.length}`);
-  console.log(`Total AERO to distribute: ${result.totalClaimedAero}`);
+  console.log(`Total gauges processed: ${results.length}`);
+  const totalTroves = results.reduce((sum, r) => sum + r.distributions.length, 0);
+  const totalRewards = results.reduce((sum, r) => sum + r.totalRewards, 0n);
+  console.log(`Total troves: ${totalTroves}`);
+  console.log(`Total AERO to distribute: ${totalRewards}`);
 
-  return result;
+  return results;
 }
 
 /**

--- a/backend/src/services/rewards-calculator.ts
+++ b/backend/src/services/rewards-calculator.ts
@@ -1,20 +1,17 @@
-import type { DistributionResult, TroveCollateralTWA, TroveDistribution } from "../types.js";
+import type { TroveCollateralTWA, TroveDistribution } from "../types.js";
 
 /**
  * Rewards Calculator Service
  *
  * This service is responsible for calculating AERO reward distributions
  * based on time-weighted average collateral amounts.
- *
- * TODO: Implement the reward calculation logic based on your specific requirements.
- * The placeholder function below provides the structure - fill in the math.
  */
 export class RewardsCalculatorService {
   /**
    * Calculate AERO rewards per troveId based on time-weighted average collateral.
    *
-   * Suggested approach:
-   * 1. Compute a weight per trove (default: TWA * activeTime)
+   * Approach:
+   * 1. Compute a weight per trove (TWA * activeTime)
    * 2. Sum weights across all troves
    * 3. Allocate pro-rata: reward = totalAeroToDistribute * weight / totalWeight
    *
@@ -45,22 +42,5 @@ export class RewardsCalculatorService {
         rewardAmount,
       };
     });
-  }
-
-  /**
-   * Build the final distribution result.
-   *
-   * @param distributions - Calculated user distributions
-   * @param result - Partial distribution result with period and other metadata
-   * @returns Complete distribution result
-   */
-  buildDistributionResult(
-    distributions: TroveDistribution[],
-    result: Omit<DistributionResult, "distributions">,
-  ): DistributionResult {
-    return {
-      ...result,
-      distributions,
-    };
   }
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -15,6 +15,7 @@ export interface ClaimedEvent {
   claimFee: bigint;
   epoch: bigint;
   blockNumber: bigint;
+  timestamp: bigint;
   transactionHash: `0x${string}`;
 }
 
@@ -24,6 +25,7 @@ export interface DistributedEvent {
   totalRewardAmount: bigint;
   epoch: bigint;
   blockNumber: bigint;
+  timestamp: bigint;
   transactionHash: `0x${string}`;
 }
 
@@ -74,16 +76,29 @@ export interface DistributionPeriod {
   endTimestamp: bigint;
 }
 
+// Per-gauge distribution information derived from epochs
+export interface GaugeDistributionInfo {
+  gauge: Address;
+  token: Address;
+  period: DistributionPeriod;
+  latestDistributedEpoch: bigint;
+  claimEpoch: bigint; // latestDistributedEpoch + 1
+  totalRewards: bigint; // sum of claims for this gauge at claimEpoch
+}
+
 // Aero LP collateral info
 export interface AeroLPCollateral {
   token: Address;
   gauge: Address;
 }
 
-// Distribution calculation result
-export interface DistributionResult {
+// Per-gauge distribution result
+export interface GaugeDistributionResult {
+  gauge: Address;
+  token: Address;
   period: DistributionPeriod;
-  lpCollaterals: AeroLPCollateral[];
-  totalClaimedAero: bigint;
+  latestDistributedEpoch: bigint;
+  claimEpoch: bigint;
+  totalRewards: bigint;
   distributions: TroveDistribution[];
 }


### PR DESCRIPTION
This is a full change based on PR #68 using latest epochs per gauge for returning rewards calculations and their respective distribution periods.