### PR TITLE
Fix: createNewBranch with setting branch addresses in bold token

### DIFF
--- a/contracts/src/BoldToken.sol
+++ b/contracts/src/BoldToken.sol
@@ -56,6 +56,34 @@ contract BoldToken is Ownable, IBoldToken, ERC20Permit {
         emit ActivePoolAddressAdded(_activePoolAddress);
     }
 
+    function setBranchAddressesViaCollateralRegistry(
+        address _troveManagerAddress,
+        address _stabilityPoolAddress,
+        address _borrowerOperationsAddress,
+        address _activePoolAddress
+    ) external {
+        //only collateral registry can call this function
+        _requireCallerIsCollateralRegistry();
+
+        //set branch addresses, but do not allow overriding existing values.
+        require(!troveManagerAddresses[_troveManagerAddress], "BoldToken: TroveManager address already set");
+        require(!stabilityPoolAddresses[_stabilityPoolAddress], "BoldToken: StabilityPool address already set");
+        require(!borrowerOperationsAddresses[_borrowerOperationsAddress], "BoldToken: BorrowerOperations address already set");
+        require(!activePoolAddresses[_activePoolAddress], "BoldToken: ActivePool address already set");
+        
+        troveManagerAddresses[_troveManagerAddress] = true;
+        emit TroveManagerAddressAdded(_troveManagerAddress);
+
+        stabilityPoolAddresses[_stabilityPoolAddress] = true;
+        emit StabilityPoolAddressAdded(_stabilityPoolAddress);
+
+        borrowerOperationsAddresses[_borrowerOperationsAddress] = true;
+        emit BorrowerOperationsAddressAdded(_borrowerOperationsAddress);
+
+        activePoolAddresses[_activePoolAddress] = true;
+        emit ActivePoolAddressAdded(_activePoolAddress);
+    }
+
     function setCollateralRegistry(address _collateralRegistryAddress) external override onlyOwner {
         collateralRegistryAddress = _collateralRegistryAddress;
         emit CollateralRegistryAddressChanged(_collateralRegistryAddress);
@@ -127,5 +155,9 @@ contract BoldToken is Ownable, IBoldToken, ERC20Permit {
 
     function _requireCallerIsStabilityPool() internal view {
         require(stabilityPoolAddresses[msg.sender], "BoldToken: Caller is not the StabilityPool");
+    }
+
+    function _requireCallerIsCollateralRegistry() internal view {
+        require(msg.sender == collateralRegistryAddress, "BoldToken: Caller is not the CollateralRegistry");
     }
 }

--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -6,6 +6,8 @@ import "openzeppelin-contracts/contracts/token/ERC20/extensions/IERC20Metadata.s
 
 import "./Interfaces/ITroveManager.sol";
 import "./Interfaces/IBoldToken.sol";
+import "./Interfaces/IAddressesRegistry.sol";
+import "./Interfaces/IActivePool.sol";
 import "./Dependencies/Constants.sol";
 import "./Dependencies/LiquityMath.sol";
 
@@ -69,18 +71,28 @@ contract CollateralRegistry is ICollateralRegistry {
 
     /*
     @notice Creates a new branch for the collateral registry
-    @param _token The collateral token for the new branch
-    @param _troveManager The trove manager for the new branch
+    @param _addressesRegistry The addresses registry for the new branch
     @param _isRedeemable Whether the new branch is redeemable
 
     @dev If the new branch is redeemable, it will be added to the redeemable branches array, but only 10 are allowed
     Alos, make sure that is doesnt already exist. Do not add a new branch using an existing known trove manager. Governor is expected to be trusted on this.
     */
-    function createNewBranch(IERC20Metadata _token, ITroveManager _troveManager, bool _isRedeemable) external {
+    function createNewBranch(IAddressesRegistry _addressesRegistry, bool _isRedeemable) external {
         require(msg.sender == collateralGovernor, "CR: Only collateral governor can create new branches");
+
+        IERC20Metadata _token = _addressesRegistry.collToken();
+        ITroveManager _troveManager = _addressesRegistry.troveManager();
+        address _stabilityPool = address(_addressesRegistry.stabilityPool());
+        address _borrowerOperations = address(_addressesRegistry.borrowerOperations());
+        IActivePool _activePool = _addressesRegistry.activePool();
+
         require(address(_token) != address(0), "CR: Token cannot be the zero address");
         require(address(_troveManager) != address(0), "CR: Trove manager cannot be the zero address");
         require(address(_token) != address(boldToken), "CR: Token cannot be the bold token");
+        require(_stabilityPool != address(0), "CR: Stability pool cannot be the zero address");
+        require(_borrowerOperations != address(0), "CR: Borrower operations cannot be the zero address");
+        require(address(_activePool) != address(0), "CR: Active pool cannot be the zero address");
+        require(address(_activePool) == address(_troveManager.activePool()), "CR: Active pool does not match trove manager");
 
         uint256 index;
         if(_isRedeemable){
@@ -93,13 +105,21 @@ contract CollateralRegistry is ICollateralRegistry {
             nonRedeemableBranchesTokens.push(_token);
             nonRedeemableBranchesTroveManagers.push(_troveManager);
         }
+        
+        // Add branch addresses in bold token
+        boldToken.setBranchAddressesViaCollateralRegistry(
+            address(_troveManager), 
+            _stabilityPool, 
+            _borrowerOperations, 
+            address(_activePool)
+        );
+        
         totalCollaterals++;
         emit CollateralBranchAdded(totalCollaterals, index, _token, _troveManager, _isRedeemable);
 
         // If AERO LP collateral, add to AeroManager
-        IActivePool activePool = _troveManager.activePool();
-        if (activePool.isAeroLPCollateral()) {
-            aeroManager.addActivePool(address(activePool));
+        if (_activePool.isAeroLPCollateral()) {
+            aeroManager.addActivePool(address(_activePool));
         }
     }
 

--- a/contracts/src/Interfaces/IBoldToken.sol
+++ b/contracts/src/Interfaces/IBoldToken.sol
@@ -14,6 +14,13 @@ interface IBoldToken is IERC20Metadata, IERC20Permit, IERC5267 {
         address _activePoolAddress
     ) external;
 
+    function setBranchAddressesViaCollateralRegistry(
+        address _troveManagerAddress,
+        address _stabilityPoolAddress,
+        address _borrowerOperationsAddress,
+        address _activePoolAddress
+    ) external;
+
     function setCollateralRegistry(address _collateralRegistryAddress) external;
 
     function mint(address _account, uint256 _amount) external;


### PR DESCRIPTION
Fixing an issue found in `CollateralRegistry.createNewBranch` where branch addresses weren't being set in `BoldToken`. This would prevent new branches from minting, burning + sending `BoldToken` to/from its stability pool.