### PR TITLE
Fix: add `ActivePool` constructor validations for aero gauge

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -13,6 +13,9 @@ fs_permissions = [
     { access = "read", path = "./addresses/" }
 ]
 
+[lint]
+lint_on_build = false
+
 [invariant]
 call_override = false
 fail_on_revert = true

--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -103,6 +103,8 @@ contract ActivePool is IActivePool {
 
         // Allow AeroManager to pull LP tokens from ActivePool
         if (_isAeroLPCollateral) {
+            require(_aeroGaugeAddress != address(0), "ActivePool: AeroGauge address cannot be 0");
+            require(IAeroGauge(_aeroGaugeAddress).stakingToken() == address(collToken), "ActivePool: staking token mismatch");
             collToken.approve(aeroManagerAddress, type(uint256).max);
         }
     }


### PR DESCRIPTION
Adds a couple `require` checks in `ActivePool` constructor for only AERO LP collateral type branches. Ensures Gauge address is non-zero address and its staking token is branch's collateral token.