### PR TITLE
Fix: add cbETH-ETH oracle decimals and price check in constructor

### DIFF
--- a/contracts/src/PriceFeeds/cbETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/cbETHPriceFeed.sol
@@ -17,7 +17,11 @@ contract cbETHPriceFeed is MainnetPriceFeedBase {
         cbEthEthOracle.aggregator = AggregatorV3Interface(_cbEthEthOracleAddress);
         cbEthEthOracle.stalenessThreshold = _cbEthEthStalenessThreshold;
         cbEthEthOracle.decimals = cbEthEthOracle.aggregator.decimals();
-        priceSource = PriceSource.primary;
+        
+        require(cbEthEthOracle.decimals == 8, "cbETHPriceFeed: cbETH-ETH oracle must have 8 decimals");
+
+        _fetchPricePrimary();
+
         // Check the oracle didn't already fail
         assert(priceSource == PriceSource.primary);
     }


### PR DESCRIPTION
Update the following in `cbETHPriceFeed` constructor:
- Add assertion of 8 decimals for second oracle cbETH-ETH
- Initial price fetch like in other price feeds
- Remove `priceSource = PriceSource.primary;`. It's redundant since `PriceSource.primary` is 0.