### PR TITLE
Fix: RedemptionHelper changes to get branch length post-createNewBranch

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -770,7 +770,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
             _uniV3Quoter: uniV3Quoter
         });
 
-        r.redemptionHelper = new RedemptionHelper(r.collateralRegistry, vars.addressesRegistries);
+        r.redemptionHelper = new RedemptionHelper(r.collateralRegistry);
     }
 
     function _deployAddressesRegistry(TroveManagerParams memory _troveManagerParams)

--- a/contracts/script/DeployRedemptionHelper.s.sol
+++ b/contracts/script/DeployRedemptionHelper.s.sol
@@ -18,14 +18,8 @@ contract DeployRedemptionHelper is Script, UseDeployment {
 
         _loadDeploymentFromManifest(string.concat("addresses/", block.chainid.toString(), ".json"));
 
-        IAddressesRegistry[] memory addresses = new IAddressesRegistry[](branches.length);
-        for (uint256 i = 0; i < branches.length; ++i) {
-            addresses[i] = branches[i].addressesRegistry;
-        }
-
         vm.startBroadcast();
-        RedemptionHelper redemptionHelper =
-            new RedemptionHelper({_collateralRegistry: collateralRegistry, _addresses: addresses});
+        RedemptionHelper redemptionHelper = new RedemptionHelper({_collateralRegistry: collateralRegistry});
 
         console.log("redemptionHelper:", address(redemptionHelper));
     }

--- a/contracts/src/Dependencies/LiquityBase.sol
+++ b/contracts/src/Dependencies/LiquityBase.sol
@@ -17,7 +17,7 @@ import "../Interfaces/ILiquityBase.sol";
 contract LiquityBase is ILiquityBase {
     IActivePool public activePool;
     IDefaultPool internal defaultPool;
-    IPriceFeed internal priceFeed;
+    IPriceFeed public priceFeed;
 
     event ActivePoolAddressChanged(address _newActivePoolAddress);
     event DefaultPoolAddressChanged(address _newDefaultPoolAddress);

--- a/contracts/src/Dependencies/LiquityBase.sol
+++ b/contracts/src/Dependencies/LiquityBase.sol
@@ -17,7 +17,7 @@ import "../Interfaces/ILiquityBase.sol";
 contract LiquityBase is ILiquityBase {
     IActivePool public activePool;
     IDefaultPool internal defaultPool;
-    IPriceFeed public priceFeed;
+    IPriceFeed internal priceFeed;
 
     event ActivePoolAddressChanged(address _newActivePoolAddress);
     event DefaultPoolAddressChanged(address _newDefaultPoolAddress);

--- a/contracts/src/Interfaces/ILiquityBase.sol
+++ b/contracts/src/Interfaces/ILiquityBase.sol
@@ -4,11 +4,9 @@ pragma solidity ^0.8.0;
 
 import "./IActivePool.sol";
 import "./IDefaultPool.sol";
-import "./IPriceFeed.sol";
 
 interface ILiquityBase {
     function activePool() external view returns (IActivePool);
-    function priceFeed() external view returns (IPriceFeed);
     function getEntireBranchDebt() external view returns (uint256);
     function getEntireBranchColl() external view returns (uint256);
 }

--- a/contracts/src/Interfaces/ILiquityBase.sol
+++ b/contracts/src/Interfaces/ILiquityBase.sol
@@ -8,6 +8,7 @@ import "./IPriceFeed.sol";
 
 interface ILiquityBase {
     function activePool() external view returns (IActivePool);
+    function priceFeed() external view returns (IPriceFeed);
     function getEntireBranchDebt() external view returns (uint256);
     function getEntireBranchColl() external view returns (uint256);
 }

--- a/contracts/src/Interfaces/ITroveManager.sol
+++ b/contracts/src/Interfaces/ITroveManager.sol
@@ -8,6 +8,7 @@ import "./IBorrowerOperations.sol";
 import "./IStabilityPool.sol";
 import "./IBoldToken.sol";
 import "./ISortedTroves.sol";
+import "./IPriceFeed.sol";
 import "../Types/LatestTroveData.sol";
 import "../Types/LatestBatchData.sol";
 
@@ -28,6 +29,7 @@ interface ITroveManager is ILiquityBase {
     //function boldToken() external view returns (IBoldToken);
     function sortedTroves() external view returns (ISortedTroves);
     function borrowerOperations() external view returns (IBorrowerOperations);
+    function getPriceFeed() external view returns (IPriceFeed);
 
     function Troves(uint256 _id)
         external

--- a/contracts/src/RedemptionHelper.sol
+++ b/contracts/src/RedemptionHelper.sol
@@ -22,21 +22,23 @@ contract RedemptionHelper is IRedemptionHelper {
         uint256 collBalanceBefore;
     }
 
-    uint256 public immutable numBranches;
     ICollateralRegistry public immutable collateralRegistry;
     IBoldToken public immutable boldToken;
-    IAddressesRegistry[] public addresses; // only used off-chain, so we don't care about storage cost
 
     constructor(ICollateralRegistry _collateralRegistry, IAddressesRegistry[] memory _addresses) {
-        require(_addresses.length == _collateralRegistry.totalCollaterals(), "Wrong number of registries");
-        numBranches = _addresses.length;
+        uint256 n = _collateralRegistry.getTroveManagers().length;
+        require(_addresses.length == n, "Wrong number of registries");
         collateralRegistry = _collateralRegistry;
         boldToken = _collateralRegistry.boldToken();
 
-        for (uint256 i = 0; i < _addresses.length; ++i) {
+        for (uint256 i = 0; i < n; ++i) {
             require(_collateralRegistry.getTroveManager(i) == _addresses[i].troveManager(), "TroveManager mismatch");
-            addresses.push(_addresses[i]);
         }
+    }
+
+    /// @notice Number of redeemable collateral branches (matches `CollateralRegistry.redeemCollateral` iteration).
+    function numBranches() public view returns (uint256) {
+        return collateralRegistry.getTroveManagers().length;
     }
 
     // Meant to be called off-chain
@@ -45,14 +47,16 @@ contract RedemptionHelper is IRedemptionHelper {
         public
         returns (SimulationContext[] memory branch, uint256 totalProportions)
     {
-        branch = new SimulationContext[](numBranches);
+        uint256 n = numBranches();
+        branch = new SimulationContext[](n);
 
         // First priority: proportional to unbacked debt
-        for (uint256 i = 0; i < numBranches; ++i) {
-            branch[i].troveManager = address(addresses[i].troveManager());
-            branch[i].sortedTroves = address(addresses[i].sortedTroves());
+        for (uint256 i = 0; i < n; ++i) {
+            ITroveManager troveManager = collateralRegistry.getTroveManager(i);
+            branch[i].troveManager = address(troveManager);
+            branch[i].sortedTroves = address(troveManager.sortedTroves());
             (branch[i].proportion, branch[i].price, branch[i].redeemable) =
-                ITroveManager(branch[i].troveManager).getUnbackedPortionPriceAndRedeemability();
+                troveManager.getUnbackedPortionPriceAndRedeemability();
             if (branch[i].redeemable) totalProportions += branch[i].proportion;
         }
 
@@ -61,7 +65,7 @@ contract RedemptionHelper is IRedemptionHelper {
 
         // Fallback: proportional to total debt
         if (totalProportions == 0) {
-            for (uint256 i = 0; i < numBranches; ++i) {
+            for (uint256 i = 0; i < n; ++i) {
                 branch[i].proportion = ITroveManager(branch[i].troveManager).getEntireBranchDebt();
                 if (branch[i].redeemable) totalProportions += branch[i].proportion;
             }
@@ -69,7 +73,7 @@ contract RedemptionHelper is IRedemptionHelper {
 
         if (totalProportions == 0) return (branch, totalProportions);
 
-        for (uint256 i = 0; i < numBranches; ++i) {
+        for (uint256 i = 0; i < n; ++i) {
             if (!branch[i].redeemable) continue;
 
             branch[i].attemptedBold = _bold * branch[i].proportion / totalProportions;
@@ -112,8 +116,10 @@ contract RedemptionHelper is IRedemptionHelper {
 
         if (totalProportions == 0) return (0, 0, redeemed);
 
+        uint256 n = numBranches();
+
         truncatedBold = _bold;
-        for (uint256 i = 0; i < numBranches; ++i) {
+        for (uint256 i = 0; i < n; ++i) {
             if (branch[i].redeemable && branch[i].proportion > 0) {
                 // Extrapolate how much the entire redeemed BOLD would
                 // have been if this branch was redeemed proportionally.
@@ -129,11 +135,11 @@ contract RedemptionHelper is IRedemptionHelper {
         }
 
         feePct = collateralRegistry.getRedemptionRateForRedeemedAmount(truncatedBold);
-        redeemed = new Redeemed[](numBranches);
+        redeemed = new Redeemed[](n);
 
-        for (uint256 i = 0; i < numBranches; ++i) {
+        for (uint256 i = 0; i < n; ++i) {
             if (branch[i].redeemable && branch[i].proportion > 0) {
-                (uint256 redemptionPrice,) = addresses[i].priceFeed().fetchRedemptionPrice();
+                (uint256 redemptionPrice,) = collateralRegistry.getTroveManager(i).priceFeed().fetchRedemptionPrice();
                 redeemed[i].bold = truncatedBold * branch[i].proportion / totalProportions;
                 redeemed[i].coll = redeemed[i].bold * (DECIMAL_PRECISION - feePct) / redemptionPrice;
             }
@@ -146,12 +152,13 @@ contract RedemptionHelper is IRedemptionHelper {
         uint256 _maxFeePct,
         uint256[] memory _minCollRedeemed
     ) external {
+        uint256 n = numBranches();
         require(_bold > 0, "Redeemed amount must be non-zero");
-        require(_minCollRedeemed.length == numBranches, "Wrong _minCollRedeemed length");
+        require(_minCollRedeemed.length == n, "Wrong _minCollRedeemed length");
 
-        RedemptionContext[] memory branch = new RedemptionContext[](numBranches);
+        RedemptionContext[] memory branch = new RedemptionContext[](n);
 
-        for (uint256 i = 0; i < numBranches; ++i) {
+        for (uint256 i = 0; i < n; ++i) {
             branch[i].collToken = collateralRegistry.getToken(i);
             branch[i].collBalanceBefore = branch[i].collToken.balanceOf(address(this));
         }
@@ -161,7 +168,7 @@ contract RedemptionHelper is IRedemptionHelper {
         boldToken.transferFrom(msg.sender, address(this), _bold);
         collateralRegistry.redeemCollateral(_bold, _maxIterationsPerCollateral, _maxFeePct);
 
-        for (uint256 i = 0; i < numBranches; ++i) {
+        for (uint256 i = 0; i < n; ++i) {
             uint256 collRedeemed = branch[i].collToken.balanceOf(address(this)) - branch[i].collBalanceBefore;
             require(collRedeemed >= _minCollRedeemed[i], "Insufficient collateral redeemed");
             if (collRedeemed > 0) branch[i].collToken.safeTransfer(msg.sender, collRedeemed);

--- a/contracts/src/RedemptionHelper.sol
+++ b/contracts/src/RedemptionHelper.sol
@@ -25,15 +25,9 @@ contract RedemptionHelper is IRedemptionHelper {
     ICollateralRegistry public immutable collateralRegistry;
     IBoldToken public immutable boldToken;
 
-    constructor(ICollateralRegistry _collateralRegistry, IAddressesRegistry[] memory _addresses) {
-        uint256 n = _collateralRegistry.getTroveManagers().length;
-        require(_addresses.length == n, "Wrong number of registries");
+    constructor(ICollateralRegistry _collateralRegistry) {
         collateralRegistry = _collateralRegistry;
         boldToken = _collateralRegistry.boldToken();
-
-        for (uint256 i = 0; i < n; ++i) {
-            require(_collateralRegistry.getTroveManager(i) == _addresses[i].troveManager(), "TroveManager mismatch");
-        }
     }
 
     /// @notice Number of redeemable collateral branches (matches `CollateralRegistry.redeemCollateral` iteration).
@@ -139,7 +133,7 @@ contract RedemptionHelper is IRedemptionHelper {
 
         for (uint256 i = 0; i < n; ++i) {
             if (branch[i].redeemable && branch[i].proportion > 0) {
-                (uint256 redemptionPrice,) = collateralRegistry.getTroveManager(i).priceFeed().fetchRedemptionPrice();
+                (uint256 redemptionPrice,) = collateralRegistry.getTroveManager(i).getPriceFeed().fetchRedemptionPrice();
                 redeemed[i].bold = truncatedBold * branch[i].proportion / totalProportions;
                 redeemed[i].coll = redeemed[i].bold * (DECIMAL_PRECISION - feePct) / redemptionPrice;
             }

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -230,6 +230,10 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         return TroveIds[_index];
     }
 
+    function getPriceFeed() external view returns (IPriceFeed) {
+        return priceFeed;
+    }
+
     // --- Trove Liquidation functions ---
 
     // --- Inner single liquidation functions ---

--- a/contracts/test/RedemptionHelper.t.sol
+++ b/contracts/test/RedemptionHelper.t.sol
@@ -82,12 +82,7 @@ contract RedemptionHelperTest is DevTestSetup {
             }
         }
 
-        IAddressesRegistry[] memory addresses = new IAddressesRegistry[](branch.length);
-        for (uint256 i = 0; i < branch.length; ++i) {
-            addresses[i] = branch[i].addressesRegistry;
-        }
-
-        redemptionHelper = new RedemptionHelper(collateralRegistry, addresses);
+        redemptionHelper = new RedemptionHelper(collateralRegistry);
     }
 
     function findAmountToBorrow(uint256 branchIdx, uint256 targetDebt, uint256 interestRate)


### PR DESCRIPTION
closes #82 

Made it a dynamic array using `getTroveManagers()` from `CollateralRegistry`. Open to suggestions on simpler changes.