### PR TITLE
Fix: AeroLPTokenPriceFeed fetchRedemptionPrice pricesource check

### DIFF
--- a/contracts/src/PriceFeeds/AeroLPTokenPriceFeed.sol
+++ b/contracts/src/PriceFeeds/AeroLPTokenPriceFeed.sol
@@ -40,7 +40,12 @@ contract AeroLPTokenPriceFeed is AeroLPTokenPriceFeedBase {
     }
 
     function fetchRedemptionPrice() external returns (uint256, bool) {
-        return _fetchPricePrimary(true);
+        // If branch is live and the primary oracle setup has been working, try to use it
+        if (priceSource == PriceSource.primary) return _fetchPricePrimary(true);
+
+        // Otherwise if branch is shut down and already using the lastGoodPrice, continue with it
+        assert(priceSource == PriceSource.lastGoodPrice);
+        return (lastGoodPrice, false);
     }
 
     //  _fetchPricePrimary returns:


### PR DESCRIPTION
Adds a conditional check for `priceSource` in `AeroLPTokenPriceFeed.fetchRedemptionPrice()`.

Currently, this is not included which causes the function to revert when called after branch shutdown. Follows same pattern as all other pricefeeds.