### PR TITLE
fix: handle killed/revived gauges in AeroManager

### DIFF
--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -248,7 +248,7 @@ contract ActivePool is IActivePool {
     /// @dev Unstakes and returns AERO LP collateral to ActivePool
     function _unstakeIfAeroLPCollateral(uint256 _amount) internal {
         if (isAeroLPCollateral) {
-            // AeroManager withdraws the _amount from AeroGauge
+            // AeroManager withdraws the _amount from AeroGauge and returns it to ActivePool
             // IAeroGauge(aeroGaugeAddress).withdraw(_amount);
             IAeroManager(aeroManagerAddress).withdraw(aeroGaugeAddress, address(collToken), _amount);
         }

--- a/contracts/src/AeroManager.sol
+++ b/contracts/src/AeroManager.sol
@@ -6,6 +6,7 @@ import "./Interfaces/IActivePool.sol";
 import "./Interfaces/ICollateralRegistry.sol";
 import "./Interfaces/IAeroManager.sol";
 import "./Interfaces/IAeroGauge.sol";
+import "./Interfaces/IAeroVoter.sol";
 import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 import "./Dependencies/Ownable.sol";
@@ -31,7 +32,12 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
 
     address public treasuryAddress;
 
+    /// @notice Amounts of tokens staked in each gauge
     mapping(address gauge => uint256) public stakedAmounts;
+    /// @notice Amounts of tokens not staked in each gauge and instead holding in AeroManager
+    mapping(address gauge => uint256) public unstakedAmounts;
+
+    /// @notice Registered active pools that can stake/withdraw
     mapping(address activePool => bool) public activePools;
 
     mapping(address gauge => uint256 epoch) public currentEpochs;
@@ -54,7 +60,9 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     uint256 public claimFeeChangeDelayPeriod = 7 days;
     uint256 public aeroTokenChangeDelayPeriod = 7 days;
 
-    event Staked(address indexed gauge, address token, uint256 amount);
+    event Staked(address indexed gauge, address token, uint256 amountReceived, uint256 amountStaked);
+    event StakedRemaining(address indexed gauge, address token, uint256 amount);
+    event Withdrawn(address indexed gauge, address token, uint256 amountSent, uint256 amountUnstaked);
     event ActivePoolAdded(address indexed activePool);
     event Claimed(address indexed gauge, uint256 total, uint256 claimFee, uint256 indexed epoch);
     event AeroDistributed(address indexed gauge, uint256 recipients, uint256 totalRewardAmount, uint256 indexed epoch);
@@ -169,13 +177,26 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
 
         // Pull LP tokens from ActivePool
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-        // Allow the gauge to pull tokens from the AeroManager on deposit()
-        IERC20(token).safeIncreaseAllowance(gauge, amount);
-        // Stake LP tokens into AeroGauge
-        IAeroGauge(gauge).deposit(amount);
-        // Log amount staked
-        stakedAmounts[gauge] += amount;
-        emit Staked(gauge, token, amount);
+        uint256 staked;
+        // Check if the gauge is alive
+        if (isAeroGaugeAlive(gauge)) {
+            // Allow the gauge to pull tokens from the AeroManager on deposit()
+            IERC20(token).safeIncreaseAllowance(gauge, amount);
+            // Stake LP tokens into AeroGauge
+            IAeroGauge(gauge).deposit(amount);
+            // Log amount staked
+            stakedAmounts[gauge] += amount;
+            
+            staked = amount;
+
+            // Try to stake any remaining unstaked tokens to the gauge
+            // This is in case of edge cases where the gauge was killed and then revived
+            _stakeRemaining(gauge, token);
+        } else {
+            // Log amount not staked
+            unstakedAmounts[gauge] += amount;
+        }
+        emit Staked(gauge, token, amount, staked);
     }
 
     /// @notice Withdraw LP from the gauge and return it to the caller `ActivePool`
@@ -184,12 +205,44 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     /// @param amount LP amount to withdraw
     function withdraw(address gauge, address token, uint256 amount) external {
         _requireCallerIsActivePool();
-        // Withdraw LP tokens from AeroGauge
-        IAeroGauge(gauge).withdraw(amount);
+        // Check for unstaked balance first
+        uint256 balance = unstakedAmounts[gauge];
+        uint256 unstaked;
+        if (amount > balance) {
+            unstaked = amount - balance;
+            // Withdraw LP tokens from AeroGauge
+            IAeroGauge(gauge).withdraw(unstaked);
+            // Log amount withdrawn
+            stakedAmounts[gauge] -= unstaked;
+            unstakedAmounts[gauge] = 0;
+        } else {
+            unstakedAmounts[gauge] -= amount;
+            // If any leftovers and gauge is alive, try to stake them
+            if (isAeroGaugeAlive(gauge)) {
+                _stakeRemaining(gauge, token);
+            }
+        }
+        // Log amount unstaked from gauge and total sent to ActivePool
+        emit Withdrawn(gauge, token, amount, unstaked);
         // Transfer LP tokens to ActivePool
         IERC20(token).safeTransfer(msg.sender, amount);
-        // Log amount withdrawn
-        stakedAmounts[gauge] -= amount;
+    }
+
+    /// @dev Tries to stake any remaining unstaked tokens from AeroManager to the gauge if it is alive
+    /// @param gauge Address of the gauge to stake remaining tokens from
+    /// @param token Address of the token to stake
+    function _stakeRemaining(address gauge, address token) internal {
+        uint256 balance = unstakedAmounts[gauge];
+        if (balance > 0) {
+            // Allow the gauge to pull tokens from the AeroManager on deposit()
+            IERC20(token).safeIncreaseAllowance(gauge, balance);
+            // Stake LP tokens into AeroGauge
+            IAeroGauge(gauge).deposit(balance);
+            // Log amount staked
+            stakedAmounts[gauge] += balance;
+            unstakedAmounts[gauge] = 0;
+            emit StakedRemaining(gauge, token, balance);
+        }
     }
 
     /// @notice Pull accrued AERO from a gauge, pay the treasury fee, and credit the net to the current epoch bucket
@@ -285,6 +338,14 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
         pendingNewClaimFee = 0;
         pendingNewClaimFeeTimestamp = 0;
         emit ClaimFeeUpdated(oldFee, claimFee);
+    }
+
+    /// @notice Checks if the AeroGauge is alive
+    /// @dev Gauges can be killed and revived, so we need to check if they are alive. When not alive, deposits into the gauge are reverted.
+    /// @param _gauge Address of the gauge to check
+    /// @return True if the gauge is alive, false otherwise
+    function isAeroGaugeAlive(address _gauge) public view returns (bool) {
+        return IAeroVoter(IAeroGauge(_gauge).voter()).isAlive(_gauge);
     }
 
     /// @notice Treasury fee as percentage of total claimed amount (`amount * claimFee / _100pct`)

--- a/contracts/src/Interfaces/IAeroManager.sol
+++ b/contracts/src/Interfaces/IAeroManager.sol
@@ -9,6 +9,7 @@ interface IAeroManager {
     event AeroTokenAddressUpdated(address _aeroTokenAddress);
     event GovernorUpdated(address _governor);
 
+    function stakedAmounts(address gauge) external view returns (uint256);
     function setAeroTokenAddress(address _aeroTokenAddress) external;
     function setGovernor(address _governor) external;
     function addActivePool(address activePool) external;

--- a/contracts/src/Interfaces/IAeroVoter.sol
+++ b/contracts/src/Interfaces/IAeroVoter.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IAeroVoter {
+    error AlreadyVotedOrDeposited();
+    error DistributeWindow();
+    error FactoryPathNotApproved();
+    error GaugeAlreadyKilled();
+    error GaugeAlreadyRevived();
+    error GaugeExists();
+    error GaugeDoesNotExist(address _pool);
+    error GaugeNotAlive(address _gauge);
+    error InactiveManagedNFT();
+    error MaximumVotingNumberTooLow();
+    error NonZeroVotes();
+    error NotAPool();
+    error NotApprovedOrOwner();
+    error NotGovernor();
+    error NotEmergencyCouncil();
+    error NotMinter();
+    error NotWhitelistedNFT();
+    error NotWhitelistedToken();
+    error SameValue();
+    error SpecialVotingWindow();
+    error TooManyPools();
+    error UnequalLengths();
+    error ZeroBalance();
+    error ZeroAddress();
+
+    event GaugeCreated(
+        address indexed poolFactory,
+        address indexed votingRewardsFactory,
+        address indexed gaugeFactory,
+        address pool,
+        address bribeVotingReward,
+        address feeVotingReward,
+        address gauge,
+        address creator
+    );
+    event GaugeKilled(address indexed gauge);
+    event GaugeRevived(address indexed gauge);
+    event Voted(
+        address indexed voter,
+        address indexed pool,
+        uint256 indexed tokenId,
+        uint256 weight,
+        uint256 totalWeight,
+        uint256 timestamp
+    );
+    event Abstained(
+        address indexed voter,
+        address indexed pool,
+        uint256 indexed tokenId,
+        uint256 weight,
+        uint256 totalWeight,
+        uint256 timestamp
+    );
+    event NotifyReward(address indexed sender, address indexed reward, uint256 amount);
+    event DistributeReward(address indexed sender, address indexed gauge, uint256 amount);
+    event WhitelistToken(address indexed whitelister, address indexed token, bool indexed _bool);
+    event WhitelistNFT(address indexed whitelister, uint256 indexed tokenId, bool indexed _bool);
+
+    /// @notice Store trusted forwarder address to pass into factories
+    function forwarder() external view returns (address);
+
+    /// @notice The ve token that governs these contracts
+    function ve() external view returns (address);
+
+    /// @notice Factory registry for valid pool / gauge / rewards factories
+    function factoryRegistry() external view returns (address);
+
+    /// @notice Address of Minter.sol
+    function minter() external view returns (address);
+
+    /// @notice Standard OZ IGovernor using ve for vote weights.
+    function governor() external view returns (address);
+
+    /// @notice Custom Epoch Governor using ve for vote weights.
+    function epochGovernor() external view returns (address);
+
+    /// @notice credibly neutral party similar to Curve's Emergency DAO
+    function emergencyCouncil() external view returns (address);
+
+    /// @dev Total Voting Weights
+    function totalWeight() external view returns (uint256);
+
+    /// @dev Most number of pools one voter can vote for at once
+    function maxVotingNum() external view returns (uint256);
+
+    // mappings
+    /// @dev Pool => Gauge
+    function gauges(address pool) external view returns (address);
+
+    /// @dev Gauge => Pool
+    function poolForGauge(address gauge) external view returns (address);
+
+    /// @dev Gauge => Fees Voting Reward
+    function gaugeToFees(address gauge) external view returns (address);
+
+    /// @dev Gauge => Bribes Voting Reward
+    function gaugeToBribe(address gauge) external view returns (address);
+
+    /// @dev Pool => Weights
+    function weights(address pool) external view returns (uint256);
+
+    /// @dev NFT => Pool => Votes
+    function votes(uint256 tokenId, address pool) external view returns (uint256);
+
+    /// @dev NFT => Total voting weight of NFT
+    function usedWeights(uint256 tokenId) external view returns (uint256);
+
+    /// @dev Nft => Timestamp of last vote (ensures single vote per epoch)
+    function lastVoted(uint256 tokenId) external view returns (uint256);
+
+    /// @dev Address => Gauge
+    function isGauge(address) external view returns (bool);
+
+    /// @dev Token => Whitelisted status
+    function isWhitelistedToken(address token) external view returns (bool);
+
+    /// @dev TokenId => Whitelisted status
+    function isWhitelistedNFT(uint256 tokenId) external view returns (bool);
+
+    /// @dev Gauge => Liveness status
+    function isAlive(address gauge) external view returns (bool);
+
+    /// @dev Gauge => Amount claimable
+    function claimable(address gauge) external view returns (uint256);
+
+    /// @notice Number of pools with a Gauge
+    function length() external view returns (uint256);
+
+    /// @notice Called by Minter to distribute weekly emissions rewards for disbursement amongst gauges.
+    /// @dev Assumes totalWeight != 0 (Will never be zero as long as users are voting).
+    ///      Throws if not called by minter.
+    /// @param _amount Amount of rewards to distribute.
+    function notifyRewardAmount(uint256 _amount) external;
+
+    /// @dev Utility to distribute to gauges of pools in range _start to _finish.
+    /// @param _start   Starting index of gauges to distribute to.
+    /// @param _finish  Ending index of gauges to distribute to.
+    function distribute(uint256 _start, uint256 _finish) external;
+
+    /// @dev Utility to distribute to gauges of pools in array.
+    /// @param _gauges Array of gauges to distribute to.
+    function distribute(address[] memory _gauges) external;
+
+    /// @notice Called by users to update voting balances in voting rewards contracts.
+    /// @param _tokenId Id of veNFT whose balance you wish to update.
+    function poke(uint256 _tokenId) external;
+
+    /// @notice Called by users to vote for pools. Votes distributed proportionally based on weights.
+    ///         Can only vote or deposit into a managed NFT once per epoch.
+    ///         Can only vote for gauges that have not been killed.
+    /// @dev Weights are distributed proportional to the sum of the weights in the array.
+    ///      Throws if length of _poolVote and _weights do not match.
+    /// @param _tokenId     Id of veNFT you are voting with.
+    /// @param _poolVote    Array of pools you are voting for.
+    /// @param _weights     Weights of pools.
+    function vote(uint256 _tokenId, address[] calldata _poolVote, uint256[] calldata _weights) external;
+
+    /// @notice Called by users to reset voting state. Required if you wish to make changes to
+    ///         veNFT state (e.g. merge, split, deposit into managed etc).
+    ///         Cannot reset in the same epoch that you voted in.
+    ///         Can vote or deposit into a managed NFT again after reset.
+    /// @param _tokenId Id of veNFT you are reseting.
+    function reset(uint256 _tokenId) external;
+
+    /// @notice Called by users to deposit into a managed NFT.
+    ///         Can only vote or deposit into a managed NFT once per epoch.
+    ///         Note that NFTs deposited into a managed NFT will be re-locked
+    ///         to the maximum lock time on withdrawal.
+    /// @dev Throws if not approved or owner.
+    ///      Throws if managed NFT is inactive.
+    ///      Throws if depositing within privileged window (one hour prior to epoch flip).
+    function depositManaged(uint256 _tokenId, uint256 _mTokenId) external;
+
+    /// @notice Called by users to withdraw from a managed NFT.
+    ///         Cannot do it in the same epoch that you deposited into a managed NFT.
+    ///         Can vote or deposit into a managed NFT again after withdrawing.
+    ///         Note that the NFT withdrawn is re-locked to the maximum lock time.
+    function withdrawManaged(uint256 _tokenId) external;
+
+    /// @notice Claim emissions from gauges.
+    /// @param _gauges Array of gauges to collect emissions from.
+    function claimRewards(address[] memory _gauges) external;
+
+    /// @notice Claim bribes for a given NFT.
+    /// @dev Utility to help batch bribe claims.
+    /// @param _bribes  Array of BribeVotingReward contracts to collect from.
+    /// @param _tokens  Array of tokens that are used as bribes.
+    /// @param _tokenId Id of veNFT that you wish to claim bribes for.
+    function claimBribes(address[] memory _bribes, address[][] memory _tokens, uint256 _tokenId) external;
+
+    /// @notice Claim fees for a given NFT.
+    /// @dev Utility to help batch fee claims.
+    /// @param _fees    Array of FeesVotingReward contracts to collect from.
+    /// @param _tokens  Array of tokens that are used as fees.
+    /// @param _tokenId Id of veNFT that you wish to claim fees for.
+    function claimFees(address[] memory _fees, address[][] memory _tokens, uint256 _tokenId) external;
+
+    /// @notice Set new governor.
+    /// @dev Throws if not called by governor.
+    /// @param _governor .
+    function setGovernor(address _governor) external;
+
+    /// @notice Set new epoch based governor.
+    /// @dev Throws if not called by governor.
+    /// @param _epochGovernor .
+    function setEpochGovernor(address _epochGovernor) external;
+
+    /// @notice Set new emergency council.
+    /// @dev Throws if not called by emergency council.
+    /// @param _emergencyCouncil .
+    function setEmergencyCouncil(address _emergencyCouncil) external;
+
+    /// @notice Set maximum number of gauges that can be voted for.
+    /// @dev Throws if not called by governor.
+    ///      Throws if _maxVotingNum is too low.
+    ///      Throws if the values are the same.
+    /// @param _maxVotingNum .
+    function setMaxVotingNum(uint256 _maxVotingNum) external;
+
+    /// @notice Whitelist (or unwhitelist) token for use in bribes.
+    /// @dev Throws if not called by governor.
+    /// @param _token .
+    /// @param _bool .
+    function whitelistToken(address _token, bool _bool) external;
+
+    /// @notice Whitelist (or unwhitelist) token id for voting in last hour prior to epoch flip.
+    /// @dev Throws if not called by governor.
+    ///      Throws if already whitelisted.
+    /// @param _tokenId .
+    /// @param _bool .
+    function whitelistNFT(uint256 _tokenId, bool _bool) external;
+
+    /// @notice Create a new gauge (unpermissioned).
+    /// @dev Governor can create a new gauge for a pool with any address.
+    /// @param _poolFactory .
+    /// @param _pool .
+    function createGauge(address _poolFactory, address _pool) external returns (address);
+
+    /// @notice Kills a gauge. The gauge will not receive any new emissions and cannot be deposited into.
+    ///         Can still withdraw from gauge.
+    /// @dev Throws if not called by emergency council.
+    ///      Throws if gauge already killed.
+    /// @param _gauge .
+    function killGauge(address _gauge) external;
+
+    /// @notice Revives a killed gauge. Gauge will can receive emissions and deposits again.
+    /// @dev Throws if not called by emergency council.
+    ///      Throws if gauge is not killed.
+    /// @param _gauge .
+    function reviveGauge(address _gauge) external;
+
+    /// @dev Update claims to emissions for an array of gauges.
+    /// @param _gauges Array of gauges to update emissions for.
+    function updateFor(address[] memory _gauges) external;
+
+    /// @dev Update claims to emissions for gauges based on their pool id as stored in Voter.
+    /// @param _start   Starting index of pools.
+    /// @param _end     Ending index of pools.
+    function updateFor(uint256 _start, uint256 _end) external;
+
+    /// @dev Update claims to emissions for single gauge
+    /// @param _gauge .
+    function updateFor(address _gauge) external;
+}

--- a/contracts/test/AeroLPInvariants.t.sol
+++ b/contracts/test/AeroLPInvariants.t.sol
@@ -155,17 +155,18 @@ contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCo
     // ============ Aero LP-Specific Invariants ============
 
     /**
-     * @notice AeroManager stakedAmounts should equal ActivePool collateral balance
-     * @dev For Aero LP branches, all collateral is staked in the gauge via AeroManager
+     * @notice AeroManager `stakedAmounts + unstakedAmounts` should equal ActivePool collateral balance
+     * @dev When a gauge is killed, LP may sit on AeroManager (`unstakedAmounts`) instead of the gauge.
      */
     function invariant_StakedEqualsCollBalance() external view {
         uint256 stakedAmount = handler.getStakedAmount(address(gauge));
+        uint256 unstakedAmount = handler.getUnstakedAmount(address(gauge));
         uint256 activePoolBalance = handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX);
 
         assertEq(
-            stakedAmount,
+            stakedAmount + unstakedAmount,
             activePoolBalance,
-            "Aero LP: stakedAmounts should equal ActivePool collateral balance"
+            "Aero LP: staked + unstaked should equal ActivePool collateral balance"
         );
     }
 
@@ -218,16 +219,21 @@ contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCo
 
     /**
      * @notice Total system collateral accounting for Aero LP branch
-     * @dev Staked amount should equal active pool balance
+     * @dev ActivePool balance equals staked plus unstaked; gauge holds the staked portion.
      */
     function invariant_AeroLPCollateralAccounting() external view {
         uint256 stakedAmount = handler.getStakedAmount(address(gauge));
+        uint256 unstakedAmount = handler.getUnstakedAmount(address(gauge));
         uint256 activePoolColl = handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX);
         uint256 gaugeBalance = handler.getGaugeBalance(address(gauge));
 
-        // Core accounting invariants
-        assertEq(stakedAmount, activePoolColl, "Aero LP: Staked should match ActivePool");
+        assertEq(stakedAmount + unstakedAmount, activePoolColl, "Aero LP: Staked+unstaked should match ActivePool");
         assertEq(gaugeBalance, stakedAmount, "Aero LP: Gauge should hold staked amount");
+        assertEq(
+            handler.getManagerLpTokenBalance(address(gauge)),
+            unstakedAmount,
+            "Aero LP: LP on manager should match unstakedAmounts"
+        );
     }
 
     // ============ Debug/Logging Invariant ============
@@ -238,6 +244,7 @@ contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCo
     function invariant_callSummary() external {
         emit log_named_uint("Aero LP branch troves", handler.numTroves(AERO_LP_BRANCH_INDEX));
         emit log_named_uint("Staked amount", handler.getStakedAmount(address(gauge)));
+        emit log_named_uint("Unstaked amount", handler.getUnstakedAmount(address(gauge)));
         emit log_named_uint("Gauge balance", handler.getGaugeBalance(address(gauge)));
         emit log_named_uint("ActivePool balance", handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX));
     }

--- a/contracts/test/AeroManagerGaugeLifecycleInvariants.t.sol
+++ b/contracts/test/AeroManagerGaugeLifecycleInvariants.t.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import {AeroManager} from "src/AeroManager.sol";
+import {IActivePool} from "src/Interfaces/IActivePool.sol";
+import {IWETH} from "src/Interfaces/IWETH.sol";
+
+import {TestDeployer} from "./TestContracts/Deployment.t.sol";
+import {Accounts, TestAccounts} from "./TestContracts/Accounts.sol";
+import {AeroGaugeTester, MockAeroToken} from "./TestContracts/AeroGaugeTester.sol";
+import {WETHTester} from "./TestContracts/WETHTester.sol";
+import {AeroManagerGaugeLifecycleHandler} from "./TestContracts/AeroManagerGaugeLifecycleHandler.sol";
+import {BaseInvariantTest} from "./TestContracts/BaseInvariantTest.sol";
+
+/// @title AeroManagerGaugeLifecycleInvariants
+/// @notice Invariant + fuzz coverage for `AeroManager.stake` / `withdraw` across gauge kill and revive (mock Voter).
+contract AeroManagerGaugeLifecycleInvariants is TestAccounts, BaseInvariantTest {
+    AeroGaugeTester internal gauge;
+    WETHTester internal weth;
+    AeroManager internal aeroManagerImpl;
+    IActivePool internal aeroActivePool;
+    AeroManagerGaugeLifecycleHandler internal handler;
+
+    address internal borrowerOperationsAddr;
+
+    function setUp() public override {
+        vm.warp(block.timestamp + 600);
+
+        accounts = new Accounts();
+        createAccounts();
+
+        (A, B, C, D, E, F, G) = (
+            accountsList[0],
+            accountsList[1],
+            accountsList[2],
+            accountsList[3],
+            accountsList[4],
+            accountsList[5],
+            accountsList[6]
+        );
+
+        super.setUp();
+
+        TestDeployer deployer = new TestDeployer();
+
+        weth = new WETHTester(100 ether, 1 days);
+        gauge = new AeroGaugeTester(address(weth), deployer.AERO_TOKEN_ADDRESS());
+        MockAeroToken(gauge.rewardToken());
+
+        TestDeployer.TroveManagerParams[] memory troveManagerParamsArray = new TestDeployer.TroveManagerParams[](1);
+        troveManagerParamsArray[0] = TestDeployer.TroveManagerParams(
+            150e16,
+            110e16,
+            10e16,
+            110e16,
+            100_000_000 ether,
+            5e16,
+            10e16,
+            true,
+            address(gauge)
+        );
+
+        TestDeployer.DeployAndConnectContractsResults memory result =
+            deployer.deployAndConnectContracts(troveManagerParamsArray, IWETH(address(weth)));
+
+        TestDeployer.LiquityContractsDev memory contracts = result.contractsArray[0];
+
+        aeroManagerImpl = AeroManager(address(result.aeroManager));
+        borrowerOperationsAddr = address(contracts.borrowerOperations);
+        aeroActivePool = IActivePool(address(contracts.activePool));
+
+        uint256 initialCollAmount = 10_000_000e18;
+        for (uint256 i = 0; i < 6; i++) {
+            address acc = accountsList[i];
+            deal(address(weth), acc, initialCollAmount);
+            vm.startPrank(acc);
+            IERC20(address(weth)).approve(borrowerOperationsAddr, initialCollAmount);
+            vm.stopPrank();
+        }
+
+        handler = new AeroManagerGaugeLifecycleHandler(
+            IWETH(address(weth)), gauge, aeroManagerImpl, aeroActivePool, borrowerOperationsAddr, adam
+        );
+        vm.label(address(handler), "AeroManagerGaugeLifecycleHandler");
+        targetContract(address(handler));
+    }
+
+    /// @notice ActivePool accounting tracks all LP whether it sits in the gauge or on AeroManager (unstaked buffer).
+    function invariant_collBalanceEqualsStakedPlusUnstaked() external view {
+        uint256 coll = aeroActivePool.getCollBalance();
+        uint256 st = aeroManagerImpl.stakedAmounts(address(gauge));
+        uint256 unst = aeroManagerImpl.unstakedAmounts(address(gauge));
+        assertEq(coll, st + unst, "collBalance != staked + unstaked");
+    }
+
+    /// @notice LP exists only on gauge or AeroManager (never idle on ActivePool for Aero LP).
+    function invariant_physicalLpMatchesAccounting() external view {
+        uint256 onGauge = IERC20(address(weth)).balanceOf(address(gauge));
+        uint256 onManager = IERC20(address(weth)).balanceOf(address(aeroManagerImpl));
+        uint256 st = aeroManagerImpl.stakedAmounts(address(gauge));
+        uint256 unst = aeroManagerImpl.unstakedAmounts(address(gauge));
+        assertEq(onGauge + onManager, st + unst, "physical LP != staked + unstaked");
+        assertEq(IERC20(address(weth)).balanceOf(address(aeroActivePool)), 0, "LP dust on ActivePool");
+    }
+
+    /// @notice `isAeroGaugeAlive` tracks the mock voter flag.
+    function invariant_aliveMatchesVoter() external view {
+        assertEq(
+            aeroManagerImpl.isAeroGaugeAlive(address(gauge)),
+            gauge.aeroVoter().isAlive(address(gauge)),
+            "isAeroGaugeAlive mismatch"
+        );
+    }
+
+    /// @dev Deterministic fuzz: bounded op sequence, then assert same invariants as above.
+    function testFuzz_stakeWithdrawKillReviveSequence(uint256 seed, uint8 numOps) public {
+        numOps = uint8(bound(uint256(numOps), 1, 64));
+        for (uint256 i; i < numOps; i++) {
+            uint256 r = uint256(keccak256(abi.encode(seed, i)));
+            uint256 op = r % 5;
+            if (op == 0) handler.killGauge();
+            else if (op == 1) handler.reviveGauge();
+            else if (op == 2) handler.stake(r >> 8);
+            else if (op == 3) handler.withdraw(r >> 16);
+            else {
+                if (r % 2 == 0) handler.killGauge();
+                else handler.reviveGauge();
+            }
+        }
+        _assertAccounting();
+    }
+
+    function _assertAccounting() internal view {
+        uint256 coll = aeroActivePool.getCollBalance();
+        uint256 st = aeroManagerImpl.stakedAmounts(address(gauge));
+        uint256 unst = aeroManagerImpl.unstakedAmounts(address(gauge));
+        assertEq(coll, st + unst);
+
+        uint256 onGauge = IERC20(address(weth)).balanceOf(address(gauge));
+        uint256 onManager = IERC20(address(weth)).balanceOf(address(aeroManagerImpl));
+        assertEq(onGauge + onManager, st + unst);
+        assertEq(IERC20(address(weth)).balanceOf(address(aeroActivePool)), 0);
+        assertEq(aeroManagerImpl.isAeroGaugeAlive(address(gauge)), gauge.aeroVoter().isAlive(address(gauge)));
+    }
+}

--- a/contracts/test/TestContracts/AeroGaugeTester.sol
+++ b/contracts/test/TestContracts/AeroGaugeTester.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.24;
 import "openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "src/Interfaces/IAeroGauge.sol";
 
+import "./MockAeroVoter.sol";
+
 contract MockAeroToken is ERC20 {
     constructor() ERC20("Mock AERO", "MAERO") {}
 
@@ -20,6 +22,7 @@ contract AeroGaugeTester is IAeroGauge {
 
     address public stakingToken;
     MockAeroToken public aeroToken;
+    MockAeroVoter public immutable aeroVoter;
     mapping(address user => uint256 amount) public balanceOf;
 
     address nullAddress = address(0);
@@ -28,6 +31,7 @@ contract AeroGaugeTester is IAeroGauge {
     constructor(address _stakingToken, address _rewardToken) {
         stakingToken = _stakingToken;
         aeroToken = _rewardToken == address(0) ? new MockAeroToken() : MockAeroToken(_rewardToken);
+        aeroVoter = new MockAeroVoter();
     }
 
     /// @notice Address of the token (AERO) rewarded to stakers
@@ -42,7 +46,7 @@ contract AeroGaugeTester is IAeroGauge {
 
     /// @notice Address of Protocol Voter
     function voter() external view returns (address) {
-        return nullAddress;
+        return address(aeroVoter);
     }
 
     /// @notice Address of Protocol Voting Escrow

--- a/contracts/test/TestContracts/AeroLPInvariantsTestHandler.t.sol
+++ b/contracts/test/TestContracts/AeroLPInvariantsTestHandler.t.sol
@@ -5,6 +5,7 @@ import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {Strings} from "openzeppelin-contracts/contracts/utils/Strings.sol";
 import {AeroManager} from "src/AeroManager.sol";
 import {IAeroManager} from "src/Interfaces/IAeroManager.sol";
+import {IAeroGauge} from "src/Interfaces/IAeroGauge.sol";
 import {InvariantsTestHandler} from "./InvariantsTestHandler.t.sol";
 import {BaseMultiCollateralTest} from "./BaseMultiCollateralTest.sol";
 import {TestDeployer} from "./Deployment.t.sol";
@@ -64,12 +65,23 @@ contract AeroLPInvariantsTestHandler is InvariantsTestHandler {
     function getStakedAmount(address _gauge) external view returns (uint256) {
         return AeroManager(address(aeroManager)).stakedAmounts(_gauge);
     }
+
+    /// @notice LP held on AeroManager when the gauge is killed (buffer before restake).
+    function getUnstakedAmount(address _gauge) external view returns (uint256) {
+        return AeroManager(address(aeroManager)).unstakedAmounts(_gauge);
+    }
     
     /**
      * @notice Get the gauge balance held by AeroManager
      */
     function getGaugeBalance(address _gauge) external view returns (uint256) {
         return IERC20(_gauge).balanceOf(address(aeroManager));
+    }
+
+    /// @notice LP token balance on AeroManager (should match `unstakedAmounts` in normal paths).
+    function getManagerLpTokenBalance(address _gauge) external view returns (uint256) {
+        address token = IAeroGauge(_gauge).stakingToken();
+        return IERC20(token).balanceOf(address(aeroManager));
     }
     
     /**

--- a/contracts/test/TestContracts/AeroManagerGaugeLifecycleHandler.sol
+++ b/contracts/test/TestContracts/AeroManagerGaugeLifecycleHandler.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+
+import {AeroGaugeTester} from "./AeroGaugeTester.sol";
+import {AeroManager} from "src/AeroManager.sol";
+import {IActivePool} from "src/Interfaces/IActivePool.sol";
+import {IWETH} from "src/Interfaces/IWETH.sol";
+
+/// @notice Randomized calls for invariant runs: kill/revive gauge (via mock Voter), stake, withdraw.
+/// @dev All mutations use `vm.prank`/`deal` so the handler never reverts on valid bounds (`fail_on_revert = true`).
+contract AeroManagerGaugeLifecycleHandler is Test {
+    IWETH public weth;
+    AeroGaugeTester public gauge;
+    AeroManager public aeroManager;
+    IActivePool public activePool;
+    address public borrowerOperations;
+    address public withdrawRecipient;
+
+    uint256 public constant MAX_STAKE = 500_000e18;
+
+    constructor(
+        IWETH _weth,
+        AeroGaugeTester _gauge,
+        AeroManager _aeroManager,
+        IActivePool _activePool,
+        address _borrowerOperations,
+        address _withdrawRecipient
+    ) {
+        weth = _weth;
+        gauge = _gauge;
+        aeroManager = _aeroManager;
+        activePool = _activePool;
+        borrowerOperations = _borrowerOperations;
+        withdrawRecipient = _withdrawRecipient;
+    }
+
+    function killGauge() external {
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+    }
+
+    function reviveGauge() external {
+        gauge.aeroVoter().setGaugeAlive(address(gauge), true);
+    }
+
+    function stake(uint256 amountSeed) external {
+        uint256 amt = bound(amountSeed, 1, MAX_STAKE);
+        deal(address(weth), borrowerOperations, amt);
+        vm.startPrank(borrowerOperations);
+        IERC20(address(weth)).transfer(address(activePool), amt);
+        activePool.accountForReceivedColl(amt);
+        vm.stopPrank();
+    }
+
+    function withdraw(uint256 amountSeed) external {
+        uint256 bal = activePool.getCollBalance();
+        if (bal == 0) return;
+        uint256 amt = bound(amountSeed, 1, bal);
+        vm.prank(borrowerOperations);
+        activePool.sendColl(withdrawRecipient, amt);
+    }
+}

--- a/contracts/test/TestContracts/MockAeroVoter.sol
+++ b/contracts/test/TestContracts/MockAeroVoter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/// @dev Minimal Aerodrome Voter stub: AeroManager only needs `isAlive(gauge)`.
+///      When no override is set for a gauge, the gauge is treated as alive (matches a newly deployed gauge).
+contract MockAeroVoter {
+    mapping(address gauge => bool hasOverride) private _hasOverride;
+    mapping(address gauge => bool alive) private _alive;
+
+    function setGaugeAlive(address gauge, bool alive) external {
+        _hasOverride[gauge] = true;
+        _alive[gauge] = alive;
+    }
+
+    function isAlive(address gauge) external view returns (bool) {
+        if (!_hasOverride[gauge]) return true;
+        return _alive[gauge];
+    }
+}

--- a/contracts/test/aeroManager.t.sol
+++ b/contracts/test/aeroManager.t.sol
@@ -542,4 +542,110 @@ contract AeroManagerTest is DevTestSetup {
         aeroManagerImpl.setGovernor(newGov);
         assertEq(aeroManagerImpl.governor(), newGov);
     }
+
+    // --- Gauge killed / revived (Voter.isAlive), unstaked buffer, _stakeRemaining ---
+
+    function test_isAeroGaugeAlive_followsMockVoter() public {
+        assertTrue(aeroManagerImpl.isAeroGaugeAlive(address(gauge)));
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        assertFalse(aeroManagerImpl.isAeroGaugeAlive(address(gauge)));
+        gauge.aeroVoter().setGaugeAlive(address(gauge), true);
+        assertTrue(aeroManagerImpl.isAeroGaugeAlive(address(gauge)));
+    }
+
+    function test_stake_whenGaugeKilled_holdsUnstaked_doesNotTouchGauge() public {
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        uint256 amount = 7e18;
+        _stakeThroughActivePool(amount);
+
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), amount);
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), 0);
+        assertEq(weth.balanceOf(address(gauge)), 0);
+        assertEq(weth.balanceOf(address(aeroManagerImpl)), amount);
+    }
+
+    function test_stake_whenGaugeRevived_afterKill_restakesPriorUnstaked() public {
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        uint256 first = 4e18;
+        _stakeThroughActivePool(first);
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), first);
+
+        gauge.aeroVoter().setGaugeAlive(address(gauge), true);
+        uint256 second = 3e18;
+        deal(address(weth), address(borrowerOperations), second);
+        vm.startPrank(address(borrowerOperations));
+        weth.transfer(address(aeroActivePool), second);
+        aeroActivePool.accountForReceivedColl(second);
+        vm.stopPrank();
+
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), first + second);
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 0);
+        assertEq(weth.balanceOf(address(gauge)), first + second);
+        assertEq(weth.balanceOf(address(aeroManagerImpl)), 0);
+    }
+
+    function test_withdraw_fromUnstakedOnly_whenGaugeAlive_restakesLeftovers() public {
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        _stakeThroughActivePool(10e18);
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 10e18);
+
+        gauge.aeroVoter().setGaugeAlive(address(gauge), true);
+
+        uint256 preRecipient = weth.balanceOf(A);
+        vm.prank(address(borrowerOperations));
+        aeroActivePool.sendColl(A, 4e18);
+
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 0);
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), 6e18);
+        assertEq(weth.balanceOf(A), preRecipient + 4e18);
+        assertEq(weth.balanceOf(address(gauge)), 6e18);
+    }
+
+    function test_withdraw_mixed_unstakedAndStaked_pullsShortfallFromGauge() public {
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        _stakeThroughActivePool(3e18);
+        gauge.aeroVoter().setGaugeAlive(address(gauge), true);
+        deal(address(weth), address(borrowerOperations), 10e18);
+        vm.startPrank(address(borrowerOperations));
+        weth.transfer(address(aeroActivePool), 10e18);
+        aeroActivePool.accountForReceivedColl(10e18);
+        vm.stopPrank();
+
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), 13e18);
+
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        deal(address(weth), address(borrowerOperations), 2e18);
+        vm.startPrank(address(borrowerOperations));
+        weth.transfer(address(aeroActivePool), 2e18);
+        aeroActivePool.accountForReceivedColl(2e18);
+        vm.stopPrank();
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 2e18);
+
+        vm.prank(address(borrowerOperations));
+        aeroActivePool.sendColl(A, 5e18);
+
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 0);
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), 10e18);
+    }
+
+    function test_withdraw_whenGaugeKilled_usesGaugeForAmountBeyondUnstaked() public {
+        _stakeThroughActivePool(8e18);
+        gauge.aeroVoter().setGaugeAlive(address(gauge), false);
+        deal(address(weth), address(borrowerOperations), 2e18);
+        vm.startPrank(address(borrowerOperations));
+        weth.transfer(address(aeroActivePool), 2e18);
+        aeroActivePool.accountForReceivedColl(2e18);
+        vm.stopPrank();
+
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 2e18);
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), 8e18);
+
+        uint256 preA = weth.balanceOf(A);
+        vm.prank(address(borrowerOperations));
+        aeroActivePool.sendColl(A, 7e18);
+
+        assertEq(weth.balanceOf(A), preA + 7e18);
+        assertEq(aeroManagerImpl.stakedAmounts(address(gauge)), 3e18);
+        assertEq(aeroManagerImpl.unstakedAmounts(address(gauge)), 0);
+    }
 }


### PR DESCRIPTION
An Aerodrome `Gauge` can be killed and revived by its `Voter`. When the gauge is not alive, the `Gauge.deposit(uint256 _amount)` function reverts, however `Gauge.withdraw(uint256 _amount)` is still allowed. This is problematic for `AeroManager`. That means borrower cannot deposit collateral in that branch if its gauge is killed. It will cause `openTrove` and `adjustTrove` to revert.

To solve this, Aero LP token collateral is held in `AeroManager` as fallback. It checks if gauge is alive every time `stake` and `withdraw` is called. If alive, then it deposits token in gauge. Else, keeps it in `AeroManager` contract. Since gauges can also be revived, any accumulated collateral in balance will also be staked upon every `stake` and `withdraw` call if alive again. On `withdraw`, the accumulated collateral in balance is also first to leave `AeroManager` and sent to `ActivePool`. Remaining amount requested by ActivePool is unstaked from gauge and included in transfer to ActivePool.

Additional tests included to handle this added complexity.