### PR TITLE
s115 Fix: add sanity check to updateCollateralGovernor function

### DIFF
--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -472,6 +472,7 @@ contract CollateralRegistry is ICollateralRegistry {
     /// @notice Update the collateral governor
     /// @param _newCollateralGovernor The new collateral governor address
     function updateCollateralGovernor(address _newCollateralGovernor) external onlyGovernor {
+        require(_newCollateralGovernor != collateralGovernor, "CR: Collateral governor already set to this address");
         address oldGovernor = collateralGovernor;
         collateralGovernor = _newCollateralGovernor;
         emit CollateralGovernorUpdated(oldGovernor, _newCollateralGovernor);


### PR DESCRIPTION
Requires new collateral governor address != current collateral governor address

Still allows setting collateral governor to null address as option to stop adding new branches. Decision is reversible by governor.