### PR TITLE
s108 Fix: cbETH-ETH oracle decimal assertion of 8 OR 18

### DIFF
--- a/contracts/src/PriceFeeds/cbETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/cbETHPriceFeed.sol
@@ -18,7 +18,10 @@ contract cbETHPriceFeed is MainnetPriceFeedBase {
         cbEthEthOracle.stalenessThreshold = _cbEthEthStalenessThreshold;
         cbEthEthOracle.decimals = cbEthEthOracle.aggregator.decimals();
         
-        require(cbEthEthOracle.decimals == 8, "cbETHPriceFeed: cbETH-ETH oracle must have 8 decimals");
+        require(
+            cbEthEthOracle.decimals == 8 || cbEthEthOracle.decimals == 18, 
+            "cbETHPriceFeed: cbETH-ETH oracle must have 8 or 18 decimals"
+        );
 
         _fetchPricePrimary();
 

--- a/contracts/test/priceFeeds/cbETHPriceFeed.t.sol
+++ b/contracts/test/priceFeeds/cbETHPriceFeed.t.sol
@@ -51,13 +51,22 @@ contract cbETHPriceFeedTest is Test {
         assertEq(a, b);
     }
 
-    function test_constructor_revertsIfCbEthEthDecimalsNot8() public {
+    function test_constructor_revertsIfCbEthEthDecimalsNot8Or18() public {
         ChainlinkOracleMock badDec = new ChainlinkOracleMock();
-        badDec.setDecimals(18);
+        badDec.setDecimals(19);
         badDec.setPrice(1.05e18);
         badDec.setUpdatedAt(block.timestamp);
 
-        vm.expectRevert(bytes("cbETHPriceFeed: cbETH-ETH oracle must have 8 decimals"));
+        vm.expectRevert(bytes("cbETHPriceFeed: cbETH-ETH oracle must have 8 or 18 decimals"));
+        new cbETHPriceFeed(
+            address(borrowerOperations),
+            address(ethUsd),
+            address(badDec),
+            1 days,
+            1 days
+        );
+
+        badDec.setDecimals(18);
         new cbETHPriceFeed(
             address(borrowerOperations),
             address(ethUsd),


### PR DESCRIPTION
cbETH-ETH oracle feeds are 18 decimals, not 8. This change asserts for either.