### PR TITLE
s106 Fix: remove unused setAeroManagerAddress + add sanity checks

### DIFF
--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -356,19 +356,6 @@ contract ActivePool is IActivePool {
         lastAggBatchManagementFeesUpdateTime = block.timestamp;
     }
 
-    function setAeroManagerAddress(address _newAeroManagerAddress) external {
-        _requireCallerIsAeroManager();
-
-        collToken.approve(aeroManagerAddress, 0);
-        collToken.approve(_newAeroManagerAddress, type(uint256).max);
-        
-        aeroManagerAddress = _newAeroManagerAddress;
-    }
-
-    function _requireCallerIsAeroManager() internal view {
-        require(msg.sender == aeroManagerAddress, "ActivePool: Caller is not AeroManager");
-    }
-
     // --- Shutdown ---
 
     function setShutdownFlag() external {

--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -102,6 +102,15 @@ contract CollateralRegistry is ICollateralRegistry {
         require(_borrowerOperations != address(0), "CR: Borrower operations cannot be the zero address");
         require(address(_activePool) != address(0), "CR: Active pool cannot be the zero address");
         require(address(_activePool) == address(_troveManager.activePool()), "CR: Active pool does not match trove manager");
+        
+        bool _isAeroLPCollateral = _activePool.isAeroLPCollateral();
+        if (_isAeroLPCollateral) {
+            require(
+                address(aeroManager) == address(_addressesRegistry.aeroManager())
+                && _activePool.aeroManagerAddress() == address(aeroManager), 
+                "CR: AeroManager address mismatch"
+            );
+        }
 
         uint256 index;
         if(_isRedeemable){
@@ -127,7 +136,7 @@ contract CollateralRegistry is ICollateralRegistry {
         emit CollateralBranchAdded(totalCollaterals, index, _token, _troveManager, _isRedeemable);
 
         // If AERO LP collateral, add to AeroManager
-        if (_activePool.isAeroLPCollateral()) {
+        if (_isAeroLPCollateral) {
             aeroManager.addActivePool(address(_activePool));
         }
     }

--- a/contracts/test/TestContracts/MockAddressesRegistryForCR.sol
+++ b/contracts/test/TestContracts/MockAddressesRegistryForCR.sol
@@ -11,6 +11,7 @@ contract MockAddressesRegistryForCR is IAddressesRegistry {
     IStabilityPool internal _stabilityPool;
     IBorrowerOperations internal _borrowerOperations;
     IActivePool internal _activePool;
+    IAeroManager internal _aeroManager = IAeroManager(address(0x1));
 
     function configure(
         IERC20Metadata collToken_,
@@ -24,6 +25,10 @@ contract MockAddressesRegistryForCR is IAddressesRegistry {
         _stabilityPool = stabilityPool_;
         _borrowerOperations = borrowerOperations_;
         _activePool = activePool_;
+    }
+
+    function setAeroManager(IAeroManager aeroManager_) external {
+        _aeroManager = aeroManager_;
     }
 
     function collToken() external view override returns (IERC20Metadata) {
@@ -127,7 +132,7 @@ contract MockAddressesRegistryForCR is IAddressesRegistry {
     }
 
     function aeroManager() external view override returns (IAeroManager) {
-        return IAeroManager(address(0x1));
+        return _aeroManager;
     }
 
     function setAddresses(AddressVars memory) external override {}

--- a/contracts/test/collateralRegistryExtendedCoverage.t.sol
+++ b/contracts/test/collateralRegistryExtendedCoverage.t.sol
@@ -189,6 +189,28 @@ contract CollateralRegistryExtendedCoverageTest is DevTestSetup {
         vm.prank(gov);
         vm.expectRevert("CR: Active pool does not match trove manager");
         CollateralRegistry(address(collateralRegistry)).createNewBranch(IAddressesRegistry(address(mock)), true);
+
+        TestDeployer d = _freshDeployer();
+        IERC20Metadata aeroLst = _lstToken("AEROV");
+        MockAeroGaugeForCR gauge = new MockAeroGaugeForCR(address(aeroLst), AeroManager(address(aeroManager)).aeroTokenAddress());
+        TestDeployer.AeroParams memory ap = TestDeployer.AeroParams(aeroManager, true, address(gauge));
+        TestDeployer.LiquityContractsDev memory c = _deployExtraBranch(d, aeroLst, ap);
+
+        mock.configure(aeroLst, c.troveManager, c.stabilityPool, c.borrowerOperations, c.activePool);
+        vm.prank(gov);
+        vm.expectRevert("CR: AeroManager address mismatch");
+        CollateralRegistry(address(collateralRegistry)).createNewBranch(IAddressesRegistry(address(mock)), true);
+
+        mock.setAeroManager(aeroManager);
+        vm.mockCall(
+            address(c.activePool),
+            abi.encodeCall(IActivePool.aeroManagerAddress, ()),
+            abi.encode(address(uint160(uint256(keccak256("wrongAeroManager")))))
+        );
+        vm.prank(gov);
+        vm.expectRevert("CR: AeroManager address mismatch");
+        CollateralRegistry(address(collateralRegistry)).createNewBranch(IAddressesRegistry(address(mock)), true);
+        vm.clearMockedCalls();
     }
 
     function test_updateCollateralGovernor_emitsAndUpdates() public {


### PR DESCRIPTION
AeroManager is immutable in CollateralRegistry so `setAeroManagerAddress` is unnecessary even if used, which it is not. To compensate for the immutability of the address, `CollateralRegistry.createNewBranch` now includes a new require statement to assert AeroManager address in branch's AddressesRegistry and ActivePool match the one in CollateralRegistry.