### PR TITLE
s97 Fix: keep Aero LP token staked while moving between pools

### DIFF
--- a/contracts/src/ActivePool.sol
+++ b/contracts/src/ActivePool.sol
@@ -33,6 +33,8 @@ contract ActivePool is IActivePool {
     address public immutable defaultPoolAddress;
     address public aeroManagerAddress;
 
+    address public collSurplusPoolAddress;
+
     IBoldToken public immutable boldToken;
 
     IInterestRouter public immutable interestRouter;
@@ -87,6 +89,7 @@ contract ActivePool is IActivePool {
         defaultPoolAddress = address(_addressesRegistry.defaultPool());
         interestRouter = _addressesRegistry.interestRouter();
         boldToken = _addressesRegistry.boldToken();
+        collSurplusPoolAddress = address(_addressesRegistry.collSurplusPool());
 
         emit CollTokenAddressChanged(address(collToken));
         emit BorrowerOperationsAddressChanged(borrowerOperationsAddress);
@@ -185,9 +188,17 @@ contract ActivePool is IActivePool {
 
         // If the collateral is AERO LP, unstake it
         // Transfers from AeroGauge -> AeroManager -> ActivePool
-        _unstakeIfAeroLPCollateral(_amount);
+        // old
+        // _unstakeIfAeroLPCollateral(_amount);
 
-        collToken.safeTransfer(_account, _amount);
+        // collToken.safeTransfer(_account, _amount);
+
+        // new
+        bool keepStaked = isAeroLPCollateral && (_account == address(stabilityPool) || _account == collSurplusPoolAddress);
+        if (!keepStaked) {
+            _unstakeIfAeroLPCollateral(_amount);
+            collToken.safeTransfer(_account, _amount);
+        }
     }
 
     function sendCollToDefaultPool(uint256 _amount) external override {
@@ -195,9 +206,14 @@ contract ActivePool is IActivePool {
 
         _accountForSendColl(_amount);
 
+        // old
         // If the collateral is AERO LP, unstake it
         // Transfers from AeroGauge -> AeroManager -> ActivePool
-        _unstakeIfAeroLPCollateral(_amount);
+        // _unstakeIfAeroLPCollateral(_amount);
+        
+        // new
+        // Do NOT unstake AERO LP tokens. Allow it to accrue AERO rewards in AeroManager.
+        // Only update the accounting
 
         IDefaultPool(defaultPoolAddress).receiveColl(_amount);
     }
@@ -215,12 +231,26 @@ contract ActivePool is IActivePool {
 
         _accountForReceivedColl(_amount);
 
-        // Pull Coll tokens from sender
-        collToken.safeTransferFrom(msg.sender, address(this), _amount);
+        // old
+        // // Pull Coll tokens from sender
+        // collToken.safeTransferFrom(msg.sender, address(this), _amount);
 
-        // If the collateral is AERO LP, stake it
-        // Transfers from ActivePool -> AeroManager -> AeroGauge
-        _stakeIfAeroLPCollateral(_amount);
+        // // If the collateral is AERO LP, stake it
+        // // Transfers from ActivePool -> AeroManager -> AeroGauge
+        // _stakeIfAeroLPCollateral(_amount);
+
+        // new
+        // If it is coming from default pool, the collateral is already staked
+        // and only need to update the accounting
+        bool alreadyStaked = isAeroLPCollateral && msg.sender == defaultPoolAddress;
+        if (!alreadyStaked) {
+            // Pull Coll tokens from sender
+            collToken.safeTransferFrom(msg.sender, address(this), _amount);
+
+            // If the collateral is AERO LP, stake it
+            // Transfers from ActivePool -> AeroManager -> AeroGauge
+            _stakeIfAeroLPCollateral(_amount);
+        }
     }
 
     /// @dev Updates accounting of collBalance by adding amount already received
@@ -231,7 +261,10 @@ contract ActivePool is IActivePool {
 
         // If the collateral is AERO LP, stake it
         // Transfers from ActivePool -> AeroManager -> AeroGauge
-        _stakeIfAeroLPCollateral(_amount);
+        // NOTE: if it is coming from default pool, the collateral is already staked
+        if (msg.sender != defaultPoolAddress) {
+            _stakeIfAeroLPCollateral(_amount);
+        }
     }
 
     //TODO might need to make this a factory, to keep positions separate.

--- a/contracts/src/AeroManager.sol
+++ b/contracts/src/AeroManager.sol
@@ -11,6 +11,7 @@ import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 import "./Dependencies/Ownable.sol";
 import "./Dependencies/Constants.sol";
+import "./Interfaces/ICollSurplusPool.sol";
 
 /// @title AeroManager
 /// @notice Stakes Aero LP collateral in gauges, claims AERO rewards, routes a configurable fee to treasury, and lets governance split the remainder across borrowers for withdrawal via `claimRewards`.
@@ -39,6 +40,8 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
 
     /// @notice Registered active pools that can stake/withdraw
     mapping(address activePool => bool) public activePools;
+    mapping(address stabilityPool => bool) public stabilityPools;
+    mapping(address collSurplusPool => bool) public collSurplusPools;
 
     mapping(address gauge => uint256 epoch) public currentEpochs;
     mapping(address gauge => mapping(uint256 epoch => bool isClosed)) public epochClosed;
@@ -199,12 +202,14 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
         emit Staked(gauge, token, amount, staked);
     }
 
-    /// @notice Withdraw LP from the gauge and return it to the caller `ActivePool`
+    /// @notice Withdraw LP from the gauge and return it to the caller `ActivePool` or `StabilityPool` or `CollSurplusPool`
+    /// @dev StabilityPool withdraws directly when depositor claims collGains
+    /// @dev CollSurplusPool withdraws directly when depositor claims coll surplus
     /// @param gauge Aero gauge the LP was staked in
     /// @param token LP token being returned
     /// @param amount LP amount to withdraw
     function withdraw(address gauge, address token, uint256 amount) external {
-        _requireCallerIsActivePool();
+        _requireCallerIsAPOrSPOrCSP();
         // Check for unstaked balance first
         uint256 balance = unstakedAmounts[gauge];
         uint256 unstaked;
@@ -361,16 +366,28 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     function _addActivePool(address activePool) internal {
         require(!activePools[activePool], "AeroManager: ActivePool already added");
 
-        // Double check stakingToken and rewardToken addresses from ActivePool matches in Gauge
+        // Ensure the active pool is an AERO LP collateral with matching AeroManager address
         IActivePool ap = IActivePool(activePool);
         require(ap.isAeroLPCollateral(), "AeroManager: ActivePool is not an AERO LP collateral");
         require(ap.aeroManagerAddress() == address(this), "AeroManager: ActivePool is not linked to this AeroManager");
+        
+        // Double check stability pool is linked to this active pool and not already added
+        IStabilityPool sp = IStabilityPool(address(ap.stabilityPool()));
+        require(address(sp.activePool()) == activePool, "AeroManager: StabilityPool is not linked to this ActivePool");
+        require(!stabilityPools[address(sp)], "AeroManager: StabilityPool already added");
 
+        ICollSurplusPool cs = ICollSurplusPool(ap.collSurplusPoolAddress());
+        require(address(cs.activePool()) == activePool, "AeroManager: CollSurplusPool is not linked to this ActivePool");
+        require(!collSurplusPools[address(cs)], "AeroManager: CollSurplusPool already added");
+
+        // Double check stakingToken and rewardToken addresses from ActivePool matches in Gauge
         IAeroGauge gauge = IAeroGauge(ap.aeroGaugeAddress());
         require(gauge.stakingToken() == address(ap.collToken()), "AeroManager: Staking token does not match");
         require(gauge.rewardToken() == aeroTokenAddress, "AeroManager: Reward token does not match");
 
         activePools[activePool] = true;
+        stabilityPools[address(sp)] = true;
+        collSurplusPools[address(cs)] = true;
         emit ActivePoolAdded(activePool);
     }
 
@@ -382,6 +399,11 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     /// @dev Ensures `msg.sender` is a registered Aero LP `ActivePool`
     function _requireCallerIsActivePool() internal view {
         require(activePools[msg.sender], "AeroManager: Caller is not an active pool");
+    }
+
+    /// @dev Ensures `msg.sender` is a registered Aero LP `ActivePool` or `StabilityPool`
+    function _requireCallerIsAPOrSPOrCSP() internal view {
+        require(activePools[msg.sender] || stabilityPools[msg.sender] || collSurplusPools[msg.sender], "AeroManager: Caller is not an active pool or stability pool or coll surplus pool");
     }
 
     /// @dev Ensures `msg.sender` is the configured `collateralRegistry`

--- a/contracts/src/CollSurplusPool.sol
+++ b/contracts/src/CollSurplusPool.sol
@@ -6,6 +6,8 @@ import "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./Interfaces/ICollSurplusPool.sol";
 import "./Interfaces/IAddressesRegistry.sol";
+import "./Interfaces/IActivePool.sol";
+import "./Interfaces/IAeroManager.sol";
 
 contract CollSurplusPool is ICollSurplusPool {
     using SafeERC20 for IERC20;
@@ -15,6 +17,9 @@ contract CollSurplusPool is ICollSurplusPool {
     IERC20 public immutable collToken;
     address public immutable borrowerOperationsAddress;
     address public immutable troveManagerAddress;
+
+    IActivePool public immutable activePool;
+    IAeroManager public immutable aeroManager;
 
     // deposited ether tracker
     uint256 internal collBalance;
@@ -33,6 +38,9 @@ contract CollSurplusPool is ICollSurplusPool {
         collToken = _addressesRegistry.collToken();
         borrowerOperationsAddress = address(_addressesRegistry.borrowerOperations());
         troveManagerAddress = address(_addressesRegistry.troveManager());
+
+        activePool = _addressesRegistry.activePool();
+        aeroManager = _addressesRegistry.aeroManager();
 
         emit BorrowerOperationsAddressChanged(borrowerOperationsAddress);
         emit TroveManagerAddressChanged(troveManagerAddress);
@@ -71,7 +79,18 @@ contract CollSurplusPool is ICollSurplusPool {
         collBalance = collBalance - claimableColl;
         emit CollSent(_account, claimableColl);
 
+        _unstakeIfAeroLPCollateral(claimableColl);
+
         collToken.safeTransfer(_account, claimableColl);
+    }
+
+    /// @dev Unstakes AERO LP collateral back to AeroManager and sends to this CollSurplusPool
+    function _unstakeIfAeroLPCollateral(uint256 _amount) internal {
+        bool isAeroLPCollateral = activePool.isAeroLPCollateral();
+        if (isAeroLPCollateral) {
+            address gauge = activePool.aeroGaugeAddress();
+            aeroManager.withdraw(gauge, address(collToken), _amount);
+        }
     }
 
     // --- 'require' functions ---

--- a/contracts/src/DefaultPool.sol
+++ b/contracts/src/DefaultPool.sol
@@ -79,7 +79,14 @@ contract DefaultPool is IDefaultPool {
         collBalance = newCollBalance;
 
         // Pull Coll tokens from ActivePool
-        collToken.safeTransferFrom(msg.sender, address(this), _amount);
+        // old
+        // collToken.safeTransferFrom(msg.sender, address(this), _amount);
+        // new
+        // If the collateral is AERO LP, do not pull it from the sender.
+        // We only update accounting and keep it staked in AeroManager.
+        if (!IActivePool(activePoolAddress).isAeroLPCollateral()) {
+            collToken.safeTransferFrom(msg.sender, address(this), _amount);
+        }
 
         emit DefaultPoolCollBalanceUpdated(newCollBalance);
     }

--- a/contracts/src/Interfaces/IActivePool.sol
+++ b/contracts/src/Interfaces/IActivePool.sol
@@ -49,4 +49,5 @@ interface IActivePool {
     function aeroManagerAddress() external view returns (address);
     function aeroGaugeAddress() external view returns (address);
     function collToken() external view returns (IERC20);
+    function collSurplusPoolAddress() external view returns (address);
 }

--- a/contracts/src/Interfaces/ICollSurplusPool.sol
+++ b/contracts/src/Interfaces/ICollSurplusPool.sol
@@ -2,6 +2,8 @@
 
 pragma solidity ^0.8.0;
 
+import "./IActivePool.sol";
+
 interface ICollSurplusPool {
     function getCollBalance() external view returns (uint256);
 
@@ -10,4 +12,6 @@ interface ICollSurplusPool {
     function accountSurplus(address _account, uint256 _amount) external;
 
     function claimColl(address _account) external;
+
+    function activePool() external view returns (IActivePool);
 }

--- a/contracts/src/StabilityPool.sol
+++ b/contracts/src/StabilityPool.sol
@@ -124,6 +124,8 @@ contract StabilityPool is LiquityBase, IStabilityPool, IStabilityPoolEvents {
     ITroveManager public immutable troveManager;
     IBoldToken public immutable boldToken;
 
+    IAeroManager public immutable aeroManager;
+
     uint256 internal collBalance; // deposited coll tracker
 
     // Tracker for Bold held in the pool. Changes when users deposit/withdraw, and when Trove debt is offset.
@@ -193,6 +195,8 @@ contract StabilityPool is LiquityBase, IStabilityPool, IStabilityPoolEvents {
         collToken = _addressesRegistry.collToken();
         troveManager = _addressesRegistry.troveManager();
         boldToken = _addressesRegistry.boldToken();
+
+        aeroManager = _addressesRegistry.aeroManager();
 
         emit TroveManagerAddressChanged(address(troveManager));
         emit BoldTokenAddressChanged(address(boldToken));
@@ -541,7 +545,17 @@ contract StabilityPool is LiquityBase, IStabilityPool, IStabilityPoolEvents {
         uint256 newCollBalance = collBalance - _collAmount;
         collBalance = newCollBalance;
         emit StabilityPoolCollBalanceUpdated(newCollBalance);
+        _unstakeIfAeroLPCollateral(_collAmount);
         collToken.safeTransfer(msg.sender, _collAmount);
+    }
+
+    /// @dev Unstakes AERO LP collateral back to AeroManager and sends to this StabilityPool
+    function _unstakeIfAeroLPCollateral(uint256 _amount) internal {
+        bool isAeroLPCollateral = activePool.isAeroLPCollateral();
+        if (isAeroLPCollateral) {
+            address gauge = activePool.aeroGaugeAddress();
+            aeroManager.withdraw(gauge, address(collToken), _amount);
+        }
     }
 
     // Send Bold to user and decrease Bold in Pool

--- a/contracts/test/AeroLPE2E.t.sol
+++ b/contracts/test/AeroLPE2E.t.sol
@@ -192,6 +192,17 @@ contract AeroLPE2E is Test, TestAccounts {
         return AeroManager(address(aeroManager));
     }
 
+    function _assertAeroLPStakedMatchesAccountedPools(string memory message) internal view {
+        uint256 accountedColl = aeroLPBranch.activePool.getCollBalance()
+            + aeroLPBranch.stabilityPool.getCollBalance()
+            + aeroLPBranch.pools.defaultPool.getCollBalance()
+            + aeroLPBranch.pools.collSurplusPool.getCollBalance();
+
+        uint256 staked = _getAeroManager().stakedAmounts(address(gauge));
+        assertEq(staked, accountedColl, message);
+        assertEq(gauge.balanceOf(address(aeroManager)), staked, "Gauge balance should match staked");
+    }
+
     // ============ Liquidation Flow Tests ============
 
     /**
@@ -228,10 +239,49 @@ contract AeroLPE2E is Test, TestAccounts {
         uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
         uint256 apBalanceAfter = aeroLPBranch.activePool.getCollBalance();
 
-        // Verify collateral was unstaked and moved
-        assertTrue(stakedAfter < stakedBefore, "Staked amount should decrease after liquidation");
-        assertTrue(apBalanceAfter < apBalanceBefore, "ActivePool balance should decrease");
-        assertEq(stakedAfter, apBalanceAfter, "Staked should match AP balance");
+        // Verify collateral accounting moved while AERO LP remains staked across pools
+        assertLt(stakedAfter, stakedBefore, "Staked amount should not increase after liquidation");
+        assertLt(apBalanceAfter, apBalanceBefore, "ActivePool balance should decrease");
+        assertGt(aeroLPBranch.stabilityPool.getCollBalance(), 0, "StabilityPool should account for offset collateral");
+        _assertAeroLPStakedMatchesAccountedPools("Staked should match accounted pool collateral");
+    }
+
+    function test_claimSurplusWithAeroLPCollateralUnstakesAndPaysOwner() public {
+        uint256 price = aeroLPBranch.priceFeed.getPrice();
+        uint256 ccr = aeroLPBranch.troveManager.get_CCR();
+        uint256 mcr = aeroLPBranch.troveManager.get_MCR();
+
+        uint256 debt = 100_000e18;
+        uint256 coll = _getMinColl(debt, price, ccr + CCR_BUFFER);
+        uint256 interestRate = 5e16;
+
+        uint256 troveIdA = _openTroveOnBranch(aeroLPBranch, 0, A, coll, debt, interestRate);
+        _openTroveOnBranch(aeroLPBranch, 0, B, coll * 5, debt, interestRate);
+
+        deal(address(boldToken), C, debt * 2);
+        vm.prank(C);
+        aeroLPBranch.stabilityPool.provideToSP(debt * 2, true);
+
+        uint256 targetICR = 107e16; // Liquidatable, but above the SP liquidation penalty.
+        aeroLPBranch.priceFeed.setPrice(targetICR * debt / coll);
+        assertLt(aeroLPBranch.troveManager.getCurrentICR(troveIdA, aeroLPBranch.priceFeed.getPrice()), mcr);
+
+        aeroLPBranch.troveManager.liquidate(troveIdA);
+
+        uint256 surplus = aeroLPBranch.pools.collSurplusPool.getCollateral(A);
+        assertGt(surplus, 0, "A should have claimable surplus");
+        _assertAeroLPStakedMatchesAccountedPools("Staked should include surplus pool before claim");
+
+        uint256 stakedBeforeClaim = _getAeroManager().stakedAmounts(address(gauge));
+        uint256 ownerBalanceBefore = lpToken.balanceOf(A);
+
+        vm.prank(A);
+        aeroLPBranch.borrowerOperations.claimCollateral();
+
+        assertEq(aeroLPBranch.pools.collSurplusPool.getCollateral(A), 0, "Surplus should be cleared");
+        assertEq(lpToken.balanceOf(A), ownerBalanceBefore + surplus, "Owner should receive surplus");
+        assertEq(stakedBeforeClaim - _getAeroManager().stakedAmounts(address(gauge)), surplus, "Claim should unstake surplus");
+        _assertAeroLPStakedMatchesAccountedPools("Staked should match accounted pools after surplus claim");
     }
 
     /**
@@ -274,13 +324,11 @@ contract AeroLPE2E is Test, TestAccounts {
         );
 
         // Check accounting after redistribution
-        uint256 stakedAfter = _getAeroManager().stakedAmounts(address(gauge));
         uint256 apBalanceAfter = aeroLPBranch.activePool.getCollBalance();
         uint256 defaultPoolBalance = aeroLPBranch.pools.defaultPool.getCollBalance();
 
-        // Key invariants for Aero LP:
-        assertEq(stakedAfter, apBalanceAfter, "Staked should match AP balance after redistribution");
-        assertEq(gauge.balanceOf(address(aeroManager)), stakedAfter, "Gauge balance should match staked");
+        // Key invariant for Aero LP: collateral remains staked while pool accounting moves between AP/DP/SP.
+        _assertAeroLPStakedMatchesAccountedPools("Staked should match accounted pool collateral after redistribution");
         
         // Total collateral preserved in pools (ActivePool + DefaultPool)
         // Note: Gas compensation (WETH) is sent to liquidator, not counted in pools

--- a/contracts/test/AeroLPInvariants.t.sol
+++ b/contracts/test/AeroLPInvariants.t.sol
@@ -155,18 +155,18 @@ contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCo
     // ============ Aero LP-Specific Invariants ============
 
     /**
-     * @notice AeroManager `stakedAmounts + unstakedAmounts` should equal ActivePool collateral balance
+     * @notice AeroManager `stakedAmounts + unstakedAmounts` should equal combined accounted collateral balances of ActivePool, StabilityPool, CollSurplusPool + DefaultPool
      * @dev When a gauge is killed, LP may sit on AeroManager (`unstakedAmounts`) instead of the gauge.
      */
     function invariant_StakedEqualsCollBalance() external view {
         uint256 stakedAmount = handler.getStakedAmount(address(gauge));
         uint256 unstakedAmount = handler.getUnstakedAmount(address(gauge));
-        uint256 activePoolBalance = handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX);
+        uint256 accountedPoolBalance = handler.getAccountedPoolCollBalance(AERO_LP_BRANCH_INDEX);
 
         assertEq(
             stakedAmount + unstakedAmount,
-            activePoolBalance,
-            "Aero LP: staked + unstaked should equal ActivePool collateral balance"
+            accountedPoolBalance,
+            "Aero LP: staked + unstaked should equal accounted pool collateral"
         );
     }
 
@@ -219,15 +219,19 @@ contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCo
 
     /**
      * @notice Total system collateral accounting for Aero LP branch
-     * @dev ActivePool balance equals staked plus unstaked; gauge holds the staked portion.
+     * @dev AP, SP, DP, and CSP accounting can all represent LP that remains staked in AeroManager.
      */
     function invariant_AeroLPCollateralAccounting() external view {
         uint256 stakedAmount = handler.getStakedAmount(address(gauge));
         uint256 unstakedAmount = handler.getUnstakedAmount(address(gauge));
-        uint256 activePoolColl = handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX);
+        uint256 accountedPoolColl = handler.getAccountedPoolCollBalance(AERO_LP_BRANCH_INDEX);
         uint256 gaugeBalance = handler.getGaugeBalance(address(gauge));
 
-        assertEq(stakedAmount + unstakedAmount, activePoolColl, "Aero LP: Staked+unstaked should match ActivePool");
+        assertEq(
+            stakedAmount + unstakedAmount,
+            accountedPoolColl,
+            "Aero LP: Staked+unstaked should match accounted pool collateral"
+        );
         assertEq(gaugeBalance, stakedAmount, "Aero LP: Gauge should hold staked amount");
         assertEq(
             handler.getManagerLpTokenBalance(address(gauge)),
@@ -247,5 +251,8 @@ contract AeroLPInvariants is Assertions, Logging, BaseInvariantTest, BaseMultiCo
         emit log_named_uint("Unstaked amount", handler.getUnstakedAmount(address(gauge)));
         emit log_named_uint("Gauge balance", handler.getGaugeBalance(address(gauge)));
         emit log_named_uint("ActivePool balance", handler.getActivePoolCollBalance(AERO_LP_BRANCH_INDEX));
+        emit log_named_uint("StabilityPool balance", handler.getStabilityPoolCollBalance(AERO_LP_BRANCH_INDEX));
+        emit log_named_uint("DefaultPool balance", handler.getDefaultPoolCollBalance(AERO_LP_BRANCH_INDEX));
+        emit log_named_uint("CollSurplusPool balance", handler.getCollSurplusPoolCollBalance(AERO_LP_BRANCH_INDEX));
     }
 }

--- a/contracts/test/TestContracts/AeroLPInvariantsTestHandler.t.sol
+++ b/contracts/test/TestContracts/AeroLPInvariantsTestHandler.t.sol
@@ -113,6 +113,30 @@ contract AeroLPInvariantsTestHandler is InvariantsTestHandler {
     }
 
     /**
+     * @notice Get the total collateral in stability pool for a branch
+     */
+    function getStabilityPoolCollBalance(uint256 branchIdx) external view returns (uint256) {
+        return branches[branchIdx].stabilityPool.getCollBalance();
+    }
+
+    /**
+     * @notice Get the total collateral in coll surplus pool for a branch
+     */
+    function getCollSurplusPoolCollBalance(uint256 branchIdx) external view returns (uint256) {
+        return branches[branchIdx].pools.collSurplusPool.getCollBalance();
+    }
+
+    /**
+     * @notice Get collateral accounted across the pools that can own staked Aero LP
+     */
+    function getAccountedPoolCollBalance(uint256 branchIdx) external view returns (uint256) {
+        return branches[branchIdx].activePool.getCollBalance()
+            + branches[branchIdx].stabilityPool.getCollBalance()
+            + branches[branchIdx].pools.defaultPool.getCollBalance()
+            + branches[branchIdx].pools.collSurplusPool.getCollBalance();
+    }
+
+    /**
      * @notice Get the AeroManager address
      */
     function getAeroManagerAddress() external view returns (address) {

--- a/contracts/test/aeroManager.t.sol
+++ b/contracts/test/aeroManager.t.sol
@@ -354,7 +354,7 @@ contract AeroManagerTest is DevTestSetup {
     }
 
     function test_withdraw_revertsIfCallerNotActivePool() public {
-        vm.expectRevert("AeroManager: Caller is not an active pool");
+        vm.expectRevert("AeroManager: Caller is not an active pool or stability pool or coll surplus pool");
         vm.prank(A);
         aeroManagerImpl.withdraw(address(gauge), address(weth), 1);
     }


### PR DESCRIPTION
Keeping LP token staked by AeroManager while collateral balance accounting updates between ActivePool, DefaultPool, StabilityPool and CollSurplusPool. This addresses two things:
1. maximizes AERO rewards accrued in AeroManager
2. eliminates issue of uncollected fee earnings for LP tokens locked in pools

While LP tokens are not staked in gauge, it collects fees from its token pair. Fee earnings are attributed to account upon token transfer, leading to some fees locked in DefaultPool, StabilityPool and CollSurplusPool if not staked.