### PR TITLE
s103 Fix: reduce max AERO claim fee

### DIFF
--- a/contracts/src/Dependencies/Constants.sol
+++ b/contracts/src/Dependencies/Constants.sol
@@ -121,7 +121,7 @@ uint256 constant GOVERNOR_TRANSFER_TIMELOCK = 3 days;
 uint256 constant MIN_BOLD_IN_SP = 1e18;
 
 uint256 constant AERO_MANAGER_FEE = 10 * _1pct; // 10%
-uint256 constant MAX_AERO_MANAGER_FEE = 50 * _1pct; // 20%
+uint256 constant MAX_AERO_MANAGER_FEE = 20 * _1pct; // 20%
 
 // Dummy contract that lets legacy Hardhat tests query some of the constants
 contract Constants {


### PR DESCRIPTION
This fixes the mismatch between actual constant value and commented value.