### PR TITLE
Fix: Disable max token approval to exchange in GasCompZapper + WETHZapper

### DIFF
--- a/contracts/src/Zappers/GasCompZapper.sol
+++ b/contracts/src/Zappers/GasCompZapper.sol
@@ -23,7 +23,7 @@ contract GasCompZapper is BaseZapper {
         // Approve coll to BorrowerOperations
         collToken.approve(address(borrowerOperations), type(uint256).max);
         // Approve Coll to exchange module (for closeTroveFromCollateral)
-        collToken.approve(address(_exchange), type(uint256).max);
+        // collToken.approve(address(_exchange), type(uint256).max); // Not using exchange at the moment
     }
 
     function openTroveWithRawETH(OpenTroveParams calldata _params) external payable returns (uint256) {

--- a/contracts/src/Zappers/WETHZapper.sol
+++ b/contracts/src/Zappers/WETHZapper.sol
@@ -14,7 +14,7 @@ contract WETHZapper is BaseZapper {
         // Approve coll to BorrowerOperations
         WETH.approve(address(borrowerOperations), type(uint256).max);
         // Approve Coll to exchange module (for closeTroveFromCollateral)
-        WETH.approve(address(_exchange), type(uint256).max);
+        // WETH.approve(address(_exchange), type(uint256).max); // Not using exchange at the moment
     }
 
     function openTroveWithRawETH(OpenTroveParams calldata _params) external payable returns (uint256) {


### PR DESCRIPTION
Commented out the token approval of exchange in zapper constructors since exchanges will be zero address.

This already exists in WrappedTokenZapper yet missed in GasCompZapper and WETHZapper.