### PR TITLE
Fix s86: misspelling of initialDebtLimit + getInitialDebtLimit

### DIFF
--- a/contracts/src/CollateralRegistry.sol
+++ b/contracts/src/CollateralRegistry.sol
@@ -399,7 +399,7 @@ contract CollateralRegistry is ICollateralRegistry {
     function updateDebtLimit(uint256 _indexTroveManager, uint256 _newDebtLimit) external onlyGovernor {
         uint256 currentDebtLimit = getTroveManager(_indexTroveManager).getDebtLimit();
         if (_newDebtLimit > currentDebtLimit) {
-            require(_newDebtLimit <= currentDebtLimit * 2 || _newDebtLimit <= getTroveManager(_indexTroveManager).getInitalDebtLimit(), "CollateralRegistry: Debt limit increase by more than 2x is not allowed");
+            require(_newDebtLimit <= currentDebtLimit * 2 || _newDebtLimit <= getTroveManager(_indexTroveManager).getInitialDebtLimit(), "CollateralRegistry: Debt limit increase by more than 2x is not allowed");
         }
         getTroveManager(_indexTroveManager).setDebtLimit(_newDebtLimit);
     }
@@ -420,7 +420,7 @@ contract CollateralRegistry is ICollateralRegistry {
     function updateNonRedeemableDebtLimit(uint256 _indexTroveManager, uint256 _newDebtLimit) external onlyGovernor {
         uint256 currentDebtLimit = getNonRedeemableTroveManager(_indexTroveManager).getDebtLimit();
         if (_newDebtLimit > currentDebtLimit) {
-            require(_newDebtLimit <= currentDebtLimit * 2 || _newDebtLimit <= getNonRedeemableTroveManager(_indexTroveManager).getInitalDebtLimit(), "CollateralRegistry: Debt limit increase by more than 2x is not allowed");
+            require(_newDebtLimit <= currentDebtLimit * 2 || _newDebtLimit <= getNonRedeemableTroveManager(_indexTroveManager).getInitialDebtLimit(), "CollateralRegistry: Debt limit increase by more than 2x is not allowed");
         }
         getNonRedeemableTroveManager(_indexTroveManager).setDebtLimit(_newDebtLimit);
     }

--- a/contracts/src/Interfaces/ITroveManager.sol
+++ b/contracts/src/Interfaces/ITroveManager.sol
@@ -79,7 +79,7 @@ interface ITroveManager is ILiquityBase {
 
     function getLatestBatchData(address _batchAddress) external view returns (LatestBatchData memory);
 
-    function getInitalDebtLimit() external view returns (uint256);
+    function getInitialDebtLimit() external view returns (uint256);
     function getDebtLimit() external view returns (uint256);
 
     // -- permissioned functions called by BorrowerOperations

--- a/contracts/src/TroveManager.sol
+++ b/contracts/src/TroveManager.sol
@@ -40,8 +40,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
 
     // Maximum debt allowed on this branch
     //Current debt on this branch is tracked via getEntireBranchDebt() in LiquityBase.sol
-    uint256 public debtLimit;
-    uint256 public initalDebtLimit;
+    uint256 internal debtLimit;
+    uint256 internal initialDebtLimit;
 
     // Liquidation penalty for troves offset to the SP
     uint256 internal immutable LIQUIDATION_PENALTY_SP;
@@ -196,7 +196,7 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         MCR = _addressesRegistry.MCR();
         SCR = _addressesRegistry.SCR();
         debtLimit = _addressesRegistry.debtLimit();
-        initalDebtLimit = debtLimit;
+        initialDebtLimit = debtLimit;
         LIQUIDATION_PENALTY_SP = _addressesRegistry.LIQUIDATION_PENALTY_SP();
         LIQUIDATION_PENALTY_REDISTRIBUTION = _addressesRegistry.LIQUIDATION_PENALTY_REDISTRIBUTION();
 
@@ -2019,8 +2019,8 @@ contract TroveManager is LiquityBase, ITroveManager, ITroveEvents {
         return debtLimit;
     }
 
-    function getInitalDebtLimit() external view returns (uint256){
-        return initalDebtLimit;
+    function getInitialDebtLimit() external view returns (uint256){
+        return initialDebtLimit;
     }
 
     function setDebtLimit(uint256 _newDebtLimit) external {


### PR DESCRIPTION
Misspelled as `initalDebtLimit` and `getInitalDebtLimit`.

Also changed `debtLimit` and `initialDebtLimit` from public to internal because of redundancy with external view functions `getDebtLimit` and `getInitialDebtLimit`.