### PR TITLE
Fix s83: deploy script to deploy and use WrappedToken of cbBTC

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -41,10 +41,13 @@ import "test/TestContracts/PriceFeedTestnet.sol";
 import "test/TestContracts/MetadataDeployment.sol";
 import "test/Utils/Logging.sol";
 import "test/Utils/StringEquality.sol";
+import {WrappedToken} from "src/ERC20Wrappers/WrappedToken.sol";
+import {IWrappedToken} from "src/Interfaces/IWrappedToken.sol";
 import "src/Zappers/WETHZapper.sol";
 import "src/Zappers/GasCompZapper.sol";
 import "src/Zappers/LeverageLSTZapper.sol";
 import "src/Zappers/LeverageWETHZapper.sol";
+import "src/Zappers/WrappedTokenZapper.sol";
 import "src/Zappers/Modules/Exchanges/HybridCurveUniV3ExchangeHelpers.sol";
 import "src/Zappers/Modules/Exchanges/HybridCurveUniV3ExchangeHelpersV2.sol";
 import {BalancerFlashLoan} from "src/Zappers/Modules/FlashLoans/BalancerFlashLoan.sol";
@@ -87,6 +90,8 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     // tapping disallowed
     IWETH WETH;
     IERC20Metadata USDC;
+
+    IERC20Metadata WRAPPED_CBBTC;
 
     // Collateral token addresses (Base Mainnet)
     address WSTETH_ADDRESS = 0xc1CBa3fCea344f92D9239c08C0568f6F2F0ee452;
@@ -203,6 +208,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         WETHZapper wethZapper;
         GasCompZapper gasCompZapper;
         ILeverageZapper leverageZapper;
+        WrappedTokenZapper wrappedTokenZapper;
     }
 
     struct LiquityContractAddresses {
@@ -710,7 +716,9 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
             vars.collaterals[2] = IERC20Metadata(RETH_ADDRESS);
 
             // cbBTC
-            vars.collaterals[3] = IERC20Metadata(CBBTC_ADDRESS);
+            // vars.collaterals[3] = IERC20Metadata(CBBTC_ADDRESS);
+            WRAPPED_CBBTC = new WrappedToken(IERC20Metadata(CBBTC_ADDRESS));
+            vars.collaterals[3] = WRAPPED_CBBTC;
 
             // cbETH
             vars.collaterals[4] = IERC20Metadata(CBETH_ADDRESS);
@@ -925,7 +933,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         );
 
         // deploy zappers
-        (contracts.gasCompZapper, contracts.wethZapper, contracts.leverageZapper) =
+        (contracts.gasCompZapper, contracts.wethZapper, contracts.leverageZapper, contracts.wrappedTokenZapper) =
             _deployZappers(contracts.addressesRegistry, contracts.collToken, _boldToken, _usdcCurvePool);
     }
 
@@ -964,7 +972,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
                 );
             }
             // cbBTC
-            if (_collTokenAddress == CBBTC_ADDRESS) {
+            if (_collTokenAddress == address(WRAPPED_CBBTC)) {
                 return new cbBTCPriceFeed(
                     _borrowerOperationsAddress,
                     CBBTC_USD_ORACLE_ADDRESS,
@@ -1004,7 +1012,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         IERC20 _collToken,
         IBoldToken _boldToken,
         ICurveStableswapNGPool _usdcCurvePool
-    ) internal returns (GasCompZapper gasCompZapper, WETHZapper wethZapper, ILeverageZapper leverageZapper) {
+    ) internal returns (GasCompZapper gasCompZapper, WETHZapper wethZapper, ILeverageZapper leverageZapper, WrappedTokenZapper wrappedTokenZapper) {
         // IFlashLoanProvider flashLoanProvider = new BalancerFlashLoan();
 
         // IExchange hybridExchange = new HybridCurveUniV3Exchange(
@@ -1023,7 +1031,9 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
         IExchange hybridExchange = IExchange(address(0));
 
         bool lst = _collToken != WETH;
-        if (lst) {
+        if (_collToken == WRAPPED_CBBTC) {
+            wrappedTokenZapper = new WrappedTokenZapper(IWrappedToken(address(_collToken)), _addressesRegistry, flashLoanProvider, hybridExchange);
+        } else if (lst) {
             gasCompZapper = new GasCompZapper(_addressesRegistry, flashLoanProvider, hybridExchange);
         } else {
             wethZapper = new WETHZapper(_addressesRegistry, flashLoanProvider, hybridExchange);


### PR DESCRIPTION
Deployment script was using cbBTC as collateral branch instead of deploying 18-decimal token wrapper and using that instead. Also included wrapped token zapper in deployment script for it.