### PR TITLE
Fix s78: Accept 18-decimal oracle in pricefeed

### DIFF
--- a/contracts/src/PriceFeeds/MainnetPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/MainnetPriceFeedBase.sol
@@ -47,7 +47,7 @@ abstract contract MainnetPriceFeedBase is IMainnetPriceFeed {
 
         borrowerOperations = IBorrowerOperations(_borrowOperationsAddress);
 
-        assert(ethUsdOracle.decimals == 8);
+        assert(ethUsdOracle.decimals == 8 || ethUsdOracle.decimals == 18);
     }
 
     function _getOracleAnswer(Oracle memory _oracle) internal view returns (uint256, bool) {


### PR DESCRIPTION
Allow oracle to be 18 decimals since we are using API3 which are all 18 decimals.