### PR TITLE
Fix s95: get rETH canonical rate from Rocket OVM Price Oracle

### DIFF
--- a/contracts/script/DeployLiquity2.s.sol
+++ b/contracts/script/DeployLiquity2.s.sol
@@ -111,6 +111,9 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
     address CBETH_ETH_ORACLE_ADDRESS = address(0); // TODO: Not activated yet
     address AERO_USD_ORACLE_ADDRESS = 0x201bC62f44f018B70E0c5eC8fF524fB26261959c;
 
+    // Canonical Rocket OVM Price Oracle
+    address RETH_RATE_PROVIDER_ADDRESS = 0x658843BB859B7b85cEAb5cF77167e3F0a78dFE7f;
+
     // Staleness thresholds
     uint256 ETH_USD_STALENESS_THRESHOLD = 24 hours;
     uint256 STETH_USD_STALENESS_THRESHOLD = 24 hours;
@@ -957,7 +960,7 @@ contract DeployLiquity2Script is DeployGovernance, UniPriceConverter, StdCheats,
                 return new RETHPriceFeed(
                     ETH_USD_ORACLE_ADDRESS,
                     RETH_ETH_ORACLE_ADDRESS,
-                    RETH_ADDRESS,
+                    RETH_RATE_PROVIDER_ADDRESS,
                     ETH_USD_STALENESS_THRESHOLD,
                     RETH_ETH_STALENESS_THRESHOLD,
                     _borrowerOperationsAddress

--- a/contracts/src/Interfaces/IRETHToken.sol
+++ b/contracts/src/Interfaces/IRETHToken.sol
@@ -3,5 +3,15 @@
 pragma solidity 0.8.24;
 
 interface IRETHToken {
+    // Unusable on Base
     function getExchangeRate() external view returns (uint256);
+    
+    // RocketOvmPriceOracle interface functions
+    // Source: https://github.com/rocket-pool/rocketpool-ovm-oracle
+
+    /// @notice The rETH exchange rate in the form of how much ETH 1 rETH is worth
+    function rate() external view returns (uint256);
+
+    /// @notice The timestamp of the block in which the rate was last updated
+    function lastUpdated() external view returns (uint256);
 }

--- a/contracts/src/PriceFeeds/RETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/RETHPriceFeed.sol
@@ -12,17 +12,20 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
     constructor(
         address _ethUsdOracleAddress,
         address _rEthEthOracleAddress,
-        address _rEthTokenAddress,
+        address _rEthRateProviderAddress,
         uint256 _ethUsdStalenessThreshold,
         uint256 _rEthEthStalenessThreshold,
         address _borrowerOperationsAddress
     )
-        CompositePriceFeed(_ethUsdOracleAddress, _rEthTokenAddress, _ethUsdStalenessThreshold, _borrowerOperationsAddress)
+        CompositePriceFeed(_ethUsdOracleAddress, _rEthRateProviderAddress, _ethUsdStalenessThreshold, _borrowerOperationsAddress)
     {
         // Store RETH-ETH oracle
         rEthEthOracle.aggregator = AggregatorV3Interface(_rEthEthOracleAddress);
         rEthEthOracle.stalenessThreshold = _rEthEthStalenessThreshold;
         rEthEthOracle.decimals = rEthEthOracle.aggregator.decimals();
+
+        // Use same staleness threshold for canonical rate as RETH-ETH
+        canonicalRateStalenessThreshold = _rEthEthStalenessThreshold;
 
         _fetchPricePrimary(false);
 
@@ -31,6 +34,8 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
     }
 
     Oracle public rEthEthOracle;
+
+    uint256 public canonicalRateStalenessThreshold;
 
     uint256 public constant RETH_ETH_DEVIATION_THRESHOLD = 2e16; // 2%
 
@@ -90,9 +95,13 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
     function _getCanonicalRate() internal view override returns (uint256, bool) {
         uint256 gasBefore = gasleft();
 
-        try IRETHToken(rateProviderAddress).getExchangeRate() returns (uint256 ethPerReth) {
+        try this.getCanonicalRate() returns (uint256 ethPerReth, uint256 lastUpdated) {
             // If rate is 0, return true
             if (ethPerReth == 0) return (0, true);
+
+            if (lastUpdated + canonicalRateStalenessThreshold <= block.timestamp) {
+                return (0, true);
+            }
 
             return (ethPerReth, false);
         } catch {
@@ -104,5 +113,9 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
             // If call to exchange rate reverts, return true
             return (0, true);
         }
+    }
+
+    function getCanonicalRate() public view returns (uint256 rate, uint256 lastUpdated) {
+        return (IRETHToken(rateProviderAddress).rate(), IRETHToken(rateProviderAddress).lastUpdated());
     }
 }

--- a/contracts/test/TestContracts/GasGuzzlerToken.sol
+++ b/contracts/test/TestContracts/GasGuzzlerToken.sol
@@ -17,6 +17,15 @@ contract GasGuzzlerToken {
         return 11e17;
     }
 
+    // RETH exchange rate getter
+    function rate() external view returns (uint256) {
+        // Expensive SLOAD loop that hits the block gas limit before completing
+        for (uint256 i = 0; i < 1000000; i++) {
+            uint256 unusedVar = pointlessStorageVar + i;
+        }
+        return 11e17;
+    }
+
     // WSTETH exchange rate getter
     function stEthPerToken() external view returns (uint256) {
         // Expensive SLOAD loop that hits the block gas limit before completing

--- a/contracts/test/TestContracts/RETHTokenMock.sol
+++ b/contracts/test/TestContracts/RETHTokenMock.sol
@@ -15,4 +15,12 @@ contract RETHTokenMock is IRETHToken {
     function setExchangeRate(uint256 _ethPerReth) external {
         ethPerReth = _ethPerReth;
     }
+
+    function rate() external view returns (uint256) {
+        return ethPerReth;
+    }
+
+    function lastUpdated() external view returns (uint256) {
+        return block.timestamp;
+    }
 }

--- a/contracts/test/priceFeeds/RETHPriceFeed.t.sol
+++ b/contracts/test/priceFeeds/RETHPriceFeed.t.sol
@@ -13,19 +13,24 @@ import "../TestContracts/RETHTokenMock.sol";
 /// @dev Lets us flip `getExchangeRate()` to revert after a successful constructor `fetch`.
 contract ToggleRethToken {
     bool public fail;
-    uint256 public rate = 1e18;
+    uint256 private _rate = 1e18;
 
     function setFail(bool f) external {
         fail = f;
     }
 
     function setRate(uint256 r) external {
-        rate = r;
+        _rate = r;
     }
 
     function getExchangeRate() external view returns (uint256) {
         if (fail) revert();
-        return rate;
+        return _rate;
+    }
+
+    function rate() external view returns (uint256) {
+        if (fail) revert();
+        return _rate;
     }
 }
 


### PR DESCRIPTION
`IRETHToken.getExchangeRate()` is not supported on Base.

Instead for Base and Optimism, RocketPool has an official rETH/ETH exchange rate oracle that pulls from L1: https://github.com/rocket-pool/rocketpool-ovm-oracle. Includes deployed addresses in README.

Modified the IRETHToken interface and canonical rate call to match new `rate()` call and also check staleness on last updated. Using same staleness threshold as rETH/ETH oracle. This is in case RocketPool stops supporting the canonical oracle at current address.

rETH canonical rate provider address also added in `DeployLiquity2.s.sol` script. 
