### PR TITLE
Fix s93: preserve 18-decimal precision for _getAmountOut output

### DIFF
--- a/contracts/src/PriceFeeds/AeroLPTokenPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/AeroLPTokenPriceFeedBase.sol
@@ -106,8 +106,8 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
     function _getTwapExchangeRates() internal view returns (ExchangeRate memory exchangeRate) {
         if (!_deployed) {
             (uint256 price0, uint256 price1) = getExchangeRates(1, TWAP_GRANULARITY);
-            exchangeRate.token1PerToken0 = price0 * 10 ** (18 - token1PoolDecimals);
-            exchangeRate.token0PerToken1 = price1 * 10 ** (18 - token0PoolDecimals);
+            exchangeRate.token1PerToken0 = price0;
+            exchangeRate.token0PerToken1 = price1;
             exchangeRate.isDown = false;
             return exchangeRate;
         }
@@ -117,8 +117,8 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
         try this.getExchangeRates(1, TWAP_GRANULARITY)
             returns (uint256 price0, uint256 price1)
         {
-            exchangeRate.token1PerToken0 = price0 * 10 ** (18 - token1PoolDecimals);
-            exchangeRate.token0PerToken1 = price1 * 10 ** (18 - token0PoolDecimals);
+            exchangeRate.token1PerToken0 = price0;
+            exchangeRate.token0PerToken1 = price1;
         } catch {
             if (gasleft() <= gasBefore / 64) revert InsufficientGasForExternalCall();
             exchangeRate.isDown = true;
@@ -213,6 +213,13 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
         return (_prices0, _prices1);
     }
 
+    /// @notice Calculate the amount out for a given amount in and reserves
+    /// @dev The amount out is returned in 18 decimals while all other values are in their own decimals
+    /// @param amountIn Amount of token in
+    /// @param tokenIn Token address of either token0 or token1
+    /// @param _reserve0 Reserve of token0
+    /// @param _reserve1 Reserve of token1
+    /// @return amountOut Amount of token out in 18 decimals
     function _getAmountOut(
         uint256 amountIn,
         address tokenIn,
@@ -226,10 +233,11 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
             (uint256 reserveA, uint256 reserveB) = tokenIn == token0 ? (_reserve0, _reserve1) : (_reserve1, _reserve0);
             amountIn = tokenIn == token0 ? amountIn * (10 ** (18 - token0PoolDecimals)) : amountIn * (10 ** (18 - token1PoolDecimals));
             uint256 y = (amountIn * _d(reserveB, reserveA)) / _d(reserveA, reserveB);
-            return (y * 10 ** (tokenIn == token0 ? token1PoolDecimals : token0PoolDecimals)) / 1e18;
+            return y;
         } else {
             (uint256 reserveA, uint256 reserveB) = tokenIn == token0 ? (_reserve0, _reserve1) : (_reserve1, _reserve0);
-            return (amountIn * reserveB) / reserveA;
+            uint256 y = (amountIn * reserveB) / reserveA;
+            return tokenIn == token0 ? y * (10 ** (18 - token1PoolDecimals)) : y * (10 ** (18 - token0PoolDecimals));
         }
     }
 

--- a/contracts/test/aeroLPTokenPriceFeed.t.sol
+++ b/contracts/test/aeroLPTokenPriceFeed.t.sol
@@ -162,6 +162,49 @@ contract AeroLPTokenPriceFeedTest is Test {
         assertFalse(exchangeRate.isDown);
     }
 
+    function test_getTwapExchangeRate_stablePairPreservesPrecisionForLowDecimalToken() public {
+        ERC20DecimalsMock s0 = new ERC20DecimalsMock("S0", "S0", 6);
+        ERC20DecimalsMock s1 = new ERC20DecimalsMock("S1", "S1", 18);
+        AeroGaugeMock g = new AeroGaugeMock(address(s0), address(s1));
+        AeroPoolMock p = g.pool();
+        p.setStable(true);
+        p.setReserves(1_000_000e6, 1_000_000e18);
+        p.setTotalSupply(1_000_000e18);
+
+        // A slight imbalance produces a token1 -> token0 marginal quote with
+        // meaningful digits below token0's 6-decimal precision.
+        p.setQuoteAmounts(1.01e18, 0);
+
+        ChainlinkOracleMock o0 = new ChainlinkOracleMock();
+        o0.setDecimals(8);
+        o0.setPrice(1e8);
+        o0.setUpdatedAt(block.timestamp);
+        ChainlinkOracleMock o1 = new ChainlinkOracleMock();
+        o1.setDecimals(8);
+        o1.setPrice(1e8);
+        o1.setUpdatedAt(block.timestamp);
+
+        AeroLPTokenPriceFeedTester stableFeed = new AeroLPTokenPriceFeedTester(
+            address(borrowerOperations),
+            IAeroGauge(address(g)),
+            address(o0),
+            address(o1),
+            1 days,
+            1 days
+        );
+
+        AeroLPTokenPriceFeedBase.ExchangeRate memory exchangeRate = stableFeed.i_getTwapExchangeRates();
+        assertEq(exchangeRate.token1PerToken0, 1_000_000_246_287_220_156);
+        assertEq(exchangeRate.token0PerToken1, 999_999_753_712_840_501);
+        assertNotEq(exchangeRate.token0PerToken1 % 1e12, 0, "sub-token precision was truncated");
+
+        // The normalized TWAP still feeds the existing fair-price path without
+        // changing the expected value of the balanced, equally priced pool.
+        (uint256 price, bool newFailure) = stableFeed.fetchPrice();
+        assertFalse(newFailure);
+        assertApproxEqAbs(price, 2e18, 1e12);
+    }
+
     function test_getTwapExchangeRate_returnsDownOnRevert() public {
         pool.setShouldRevert(true);
 


### PR DESCRIPTION
Instead of scaling the decimals back down to token decimals, `_getAmountOut` outputs amount out as 18 decimals. This is to prevent loss of precision in cases when token decimals are less than 18 decimals such as USDC.