### PR TITLE
Fix s89: enable distributeAero for multiple batches in same epoch + separate call for next epoch

### DIFF
--- a/contracts/src/AeroManager.sol
+++ b/contracts/src/AeroManager.sol
@@ -49,6 +49,8 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     mapping(address gauge => uint256 epoch) public currentEpochs;
     mapping(address gauge => mapping(uint256 epoch => bool isClosed)) public epochClosed;
     mapping(uint256 epoch => mapping(address gauge => uint256 amount)) public claimedAeroPerEpoch;
+    /// @notice AERO allocated so far for each gauge epoch across all distribution batches
+    mapping(uint256 epoch => mapping(address gauge => uint256 amount)) public distributedAeroPerEpoch;
 
     mapping(address user => mapping(address rewardToken => uint256 amount)) internal _claimableRewards;
 
@@ -71,7 +73,8 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     event Withdrawn(address indexed gauge, address token, uint256 amountSent, uint256 amountUnstaked);
     event ActivePoolAdded(address indexed activePool);
     event Claimed(address indexed gauge, uint256 total, uint256 claimFee, uint256 indexed epoch);
-    event AeroDistributed(address indexed gauge, uint256 recipients, uint256 totalRewardAmount, uint256 indexed epoch);
+    event AeroDistributed(address indexed gauge, uint256 recipients, uint256 rewardAmount, uint256 indexed epoch);
+    event AeroDistributionFinalized(address indexed gauge, uint256 totalRewardAmount, uint256 indexed epoch);
     event RewardsClaimed(address indexed user, address indexed rewardToken, uint256 amount);
     event CollateralRegistryAdded(address collateralRegistry);
     event ClaimFeeUpdated(uint256 oldFee, uint256 newFee);
@@ -81,6 +84,7 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
     event AeroTokenAddressUpdatePending(address oldAeroTokenAddress, address newAeroTokenAddress, uint256 timestamp, uint256 delayPeriod);
     event TreasuryAddressUpdated(address oldTreasuryAddress, address newTreasuryAddress);
     event EpochClosed(address indexed gauge, uint256 indexed epoch);
+    event EpochStarted(address indexed gauge, uint256 indexed epoch);
     event GovernorProposed(address indexed pendingGovernor, uint256 activateAtTimestamp);
     event GovernorUpdated(address oldGovernor, address newGovernor);
     event GovernorProposalCancelled(address indexed cancelledGovernor);
@@ -338,26 +342,47 @@ contract AeroManager is IAeroManager, ReentrancyGuard, Ownable {
         emit EpochClosed(gauge, currentEpoch);
     }
 
-    /// @notice Split a closed epoch's AERO for `gauge` across borrowers; advances the gauge epoch when the bucket is fully allocated
-    /// @dev Sum of `recipients[i].amount` must equal `claimedAeroPerEpoch[currentEpoch][gauge]` for that gauge/epoch
+    /// @notice Start the next epoch for a gauge
+    /// @param gauge Gauge address to start the next epoch for
+    function startNextEpoch(address gauge) external onlyGovernor {
+        uint256 currentEpoch = currentEpochs[gauge];
+        require(epochClosed[gauge][currentEpoch], "AeroManager: Current epoch is not closed yet to start next epoch");
+        uint256 total = claimedAeroPerEpoch[currentEpoch][gauge];
+        uint256 allocated = distributedAeroPerEpoch[currentEpoch][gauge];
+        require(total == allocated, "AeroManager: Total rewards have not been distributed yet");
+        currentEpochs[gauge]++;
+        emit EpochStarted(gauge, currentEpoch + 1);
+    }
+
+    /// @notice Allocate a batch of a closed epoch's AERO for `gauge` across borrowers
+    /// @dev Batches may not allocate more than `claimedAeroPerEpoch[currentEpoch][gauge]` in total
     /// @param gauge Gauge whose closed epoch is being paid out
-    /// @param recipients Borrower addresses and AERO amounts; must exhaust the epoch balance exactly
-    function distributeAero(address gauge, AeroRecipient[] memory recipients) external onlyGovernor {
+    /// @param recipients Borrower addresses and AERO amounts for this batch
+    /// @param _startNextEpoch Whether to start the next epoch immediately if all rewards have been distributed
+    function distributeAero(address gauge, AeroRecipient[] calldata recipients, bool _startNextEpoch) external onlyGovernor {
         uint256 currentEpoch = currentEpochs[gauge];
         require(epochClosed[gauge][currentEpoch], "AeroManager: Current epoch is not closed yet to distribute rewards");
         require(recipients.length > 0, "AeroManager: No recipients");
-        
-        uint256 rewardAmount = claimedAeroPerEpoch[currentEpoch][gauge];
-        uint256 remainingRewardAmount = rewardAmount;
+
+        uint256 total = claimedAeroPerEpoch[currentEpoch][gauge];
+        uint256 allocated = distributedAeroPerEpoch[currentEpoch][gauge];
+        require(allocated < total, "AeroManager: All rewards have already been distributed");
+        uint256 remaining = total - allocated;
         for (uint256 i; i < recipients.length; i++) {
-            require(recipients[i].amount <= remainingRewardAmount, "AeroManager: Total amount exceeds reward amount");
-            remainingRewardAmount -= recipients[i].amount;
+            require(recipients[i].amount <= remaining, "AeroManager: Total amount exceeds reward amount");
+            remaining -= recipients[i].amount;
             _claimableRewards[recipients[i].borrower][aeroTokenAddress] += recipients[i].amount;
         }
-        require(remainingRewardAmount == 0, "AeroManager: Reward amount not fully distributed");
-        emit AeroDistributed(gauge, recipients.length, rewardAmount, currentEpoch);
-        currentEpoch++;
-        currentEpochs[gauge] = currentEpoch;
+        uint256 batchAmount = total - allocated - remaining;
+        distributedAeroPerEpoch[currentEpoch][gauge] += batchAmount;
+        emit AeroDistributed(gauge, recipients.length, batchAmount, currentEpoch);
+        if (remaining == 0) {
+            emit AeroDistributionFinalized(gauge, total, currentEpoch);
+            if (_startNextEpoch) {
+                currentEpochs[gauge]++;
+                emit EpochStarted(gauge, currentEpoch + 1);
+            }
+        }
     }
 
     /// @notice Withdraw previously allocated AERO for `user` (via `distributeAero`) to the user wallet

--- a/contracts/test/AeroLPFuzz.t.sol
+++ b/contracts/test/AeroLPFuzz.t.sol
@@ -530,7 +530,7 @@ contract AeroLPFuzz is Test, TestAccounts {
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: netReward});
 
         vm.prank(governor);
-        am.distributeAero(address(gauge1), recipients);
+        am.distributeAero(address(gauge1), recipients, true);
 
         assertEq(am.currentEpochs(address(gauge1)), 1, "Epoch should increment");
         assertEq(am.claimableRewards(A), netReward, "User should have claimable rewards");
@@ -707,7 +707,7 @@ contract AeroLPFuzz is Test, TestAccounts {
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: claimed});
 
         vm.prank(governor);
-        am.distributeAero(address(gauge1), recipients);
+        am.distributeAero(address(gauge1), recipients, true);
 
         // Verify epoch incremented
         uint256 currentEpoch = am.currentEpochs(address(gauge1));

--- a/contracts/test/aeroManager.t.sol
+++ b/contracts/test/aeroManager.t.sol
@@ -231,7 +231,7 @@ contract AeroManagerTest is DevTestSetup {
         assertEq(aeroManagerImpl.claimedAeroPerEpoch(0, address(gauge)), rewardAmount);
     }
 
-    function test_distributeAero_incrementsEpoch_setsClaimable_and_userCanClaim() public {
+    function test_distributeAero_batchesAndFinalBatchAdvancesEpoch_setsClaimable_and_userCanClaim() public {
         uint256 amount = 10e18;
         _stakeThroughActivePool(amount);
 
@@ -247,17 +247,23 @@ contract AeroManagerTest is DevTestSetup {
         vm.prank(governor);
         aeroManagerImpl.closeCurrentEpoch(address(gauge));
 
-        // Allocate all epoch-0 rewards
-        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](2);
+        // Allocate epoch-0 rewards in two batches
+        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
         uint256 aAmt = rewardEpoch0 / 3;
         uint256 bAmt = rewardEpoch0 - aAmt;
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: aAmt});
-        recipients[1] = AeroManager.AeroRecipient({borrower: B, amount: bAmt});
 
         vm.prank(governor);
-        aeroManagerImpl.distributeAero(address(gauge), recipients);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
 
-        // Epoch incremented
+        assertEq(aeroManagerImpl.currentEpochs(address(gauge)), epoch0);
+        assertEq(aeroManagerImpl.distributedAeroPerEpoch(epoch0, address(gauge)), aAmt);
+
+        recipients[0] = AeroManager.AeroRecipient({borrower: B, amount: bAmt});
+        vm.prank(governor);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, true);
+
+        assertEq(aeroManagerImpl.distributedAeroPerEpoch(epoch0, address(gauge)), rewardEpoch0);
         assertEq(aeroManagerImpl.currentEpochs(address(gauge)), epoch0 + 1);
 
         // Allocations recorded
@@ -297,7 +303,7 @@ contract AeroManagerTest is DevTestSetup {
         recipients0[0] = AeroManager.AeroRecipient({borrower: A, amount: a0});
         recipients0[1] = AeroManager.AeroRecipient({borrower: B, amount: b0});
         vm.prank(governor);
-        aeroManagerImpl.distributeAero(address(gauge), recipients0);
+        aeroManagerImpl.distributeAero(address(gauge), recipients0, true);
         assertEq(aeroManagerImpl.currentEpochs(address(gauge)), 1);
 
         // ---- Epoch 1 ----
@@ -316,7 +322,7 @@ contract AeroManagerTest is DevTestSetup {
         recipients1[0] = AeroManager.AeroRecipient({borrower: A, amount: a1});
         recipients1[1] = AeroManager.AeroRecipient({borrower: B, amount: b1});
         vm.prank(governor);
-        aeroManagerImpl.distributeAero(address(gauge), recipients1);
+        aeroManagerImpl.distributeAero(address(gauge), recipients1, true);
         assertEq(aeroManagerImpl.currentEpochs(address(gauge)), 2);
 
         // Claimable should include both epochs (we didn't claim in-between)
@@ -412,7 +418,7 @@ contract AeroManagerTest is DevTestSetup {
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: 1});
         vm.prank(governor);
         vm.expectRevert("AeroManager: Current epoch is not closed yet to distribute rewards");
-        aeroManagerImpl.distributeAero(address(gauge), recipients);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
     }
 
     function test_distributeAero_revertsWhenNoRecipients() public {
@@ -420,7 +426,7 @@ contract AeroManagerTest is DevTestSetup {
         aeroManagerImpl.closeCurrentEpoch(address(gauge));
         vm.prank(governor);
         vm.expectRevert("AeroManager: No recipients");
-        aeroManagerImpl.distributeAero(address(gauge), new AeroManager.AeroRecipient[](0));
+        aeroManagerImpl.distributeAero(address(gauge), new AeroManager.AeroRecipient[](0), false);
     }
 
     function test_distributeAero_revertsWhenRecipientAmountExceedsReward() public {
@@ -433,10 +439,10 @@ contract AeroManagerTest is DevTestSetup {
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: reward + 1});
         vm.prank(governor);
         vm.expectRevert("AeroManager: Total amount exceeds reward amount");
-        aeroManagerImpl.distributeAero(address(gauge), recipients);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
     }
 
-    function test_distributeAero_revertsWhenRewardNotFullyDistributed() public {
+    function test_distributeAero_doesNotAdvanceWhenRewardNotFullyDistributed() public {
         _stakeThroughActivePool(10e18);
         aeroManagerImpl.claim(address(gauge));
         uint256 reward = aeroManagerImpl.claimedAeroPerEpoch(0, address(gauge));
@@ -445,8 +451,75 @@ contract AeroManagerTest is DevTestSetup {
         AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: reward - 1});
         vm.prank(governor);
-        vm.expectRevert("AeroManager: Reward amount not fully distributed");
-        aeroManagerImpl.distributeAero(address(gauge), recipients);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
+
+        assertEq(aeroManagerImpl.currentEpochs(address(gauge)), 0);
+        assertEq(aeroManagerImpl.distributedAeroPerEpoch(0, address(gauge)), reward - 1);
+    }
+
+    function test_distributeAero_fullDistributionWithoutStartingNextEpoch_canStartSeparately() public {
+        _stakeThroughActivePool(10e18);
+        aeroManagerImpl.claim(address(gauge));
+        uint256 reward = aeroManagerImpl.claimedAeroPerEpoch(0, address(gauge));
+        vm.prank(governor);
+        aeroManagerImpl.closeCurrentEpoch(address(gauge));
+
+        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
+        recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: reward});
+        vm.prank(governor);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
+
+        assertEq(aeroManagerImpl.currentEpochs(address(gauge)), 0);
+        assertEq(aeroManagerImpl.distributedAeroPerEpoch(0, address(gauge)), reward);
+
+        vm.prank(governor);
+        aeroManagerImpl.startNextEpoch(address(gauge));
+
+        assertEq(aeroManagerImpl.currentEpochs(address(gauge)), 1);
+        assertFalse(aeroManagerImpl.epochClosed(address(gauge), 1));
+    }
+
+    function test_startNextEpoch_revertsBeforeAllRewardsAreDistributed() public {
+        _stakeThroughActivePool(10e18);
+        aeroManagerImpl.claim(address(gauge));
+        uint256 reward = aeroManagerImpl.claimedAeroPerEpoch(0, address(gauge));
+        vm.prank(governor);
+        aeroManagerImpl.closeCurrentEpoch(address(gauge));
+
+        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
+        recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: reward - 1});
+        vm.prank(governor);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
+
+        vm.prank(governor);
+        vm.expectRevert("AeroManager: Total rewards have not been distributed yet");
+        aeroManagerImpl.startNextEpoch(address(gauge));
+    }
+
+    function test_startNextEpoch_revertsIfNotGovernor() public {
+        vm.expectRevert("AeroManager: Caller is not the governor");
+        aeroManagerImpl.startNextEpoch(address(gauge));
+    }
+
+    function test_distributeAero_revertsWhenLaterBatchExceedsRemainingReward() public {
+        _stakeThroughActivePool(10e18);
+        aeroManagerImpl.claim(address(gauge));
+        uint256 reward = aeroManagerImpl.claimedAeroPerEpoch(0, address(gauge));
+        vm.prank(governor);
+        aeroManagerImpl.closeCurrentEpoch(address(gauge));
+
+        AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
+        recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: reward - 1});
+        vm.prank(governor);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
+
+        recipients[0] = AeroManager.AeroRecipient({borrower: B, amount: 2});
+        vm.prank(governor);
+        vm.expectRevert("AeroManager: Total amount exceeds reward amount");
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
+
+        assertEq(aeroManagerImpl.distributedAeroPerEpoch(0, address(gauge)), reward - 1);
+        assertEq(aeroManagerImpl.claimableRewards(B), 0);
     }
 
     function test_distributeAero_revertsIfNotGovernor() public {
@@ -458,7 +531,7 @@ contract AeroManagerTest is DevTestSetup {
         AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: reward});
         vm.expectRevert("AeroManager: Caller is not the governor");
-        aeroManagerImpl.distributeAero(address(gauge), recipients);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, false);
     }
 
     // --- claimRewards ---
@@ -479,7 +552,7 @@ contract AeroManagerTest is DevTestSetup {
         AeroManager.AeroRecipient[] memory recipients = new AeroManager.AeroRecipient[](1);
         recipients[0] = AeroManager.AeroRecipient({borrower: A, amount: oldRewardAmount});
         vm.prank(governor);
-        aeroManagerImpl.distributeAero(address(gauge), recipients);
+        aeroManagerImpl.distributeAero(address(gauge), recipients, true);
 
         MockAeroToken newTok = new MockAeroToken();
         vm.prank(governor);
@@ -590,7 +663,7 @@ contract AeroManagerTest is DevTestSetup {
         AeroManager.AeroRecipient[] memory recipients0 = new AeroManager.AeroRecipient[](1);
         recipients0[0] = AeroManager.AeroRecipient({borrower: A, amount: oldClaimed});
         vm.prank(governor);
-        aeroManagerImpl.distributeAero(address(gauge), recipients0);
+        aeroManagerImpl.distributeAero(address(gauge), recipients0, true);
 
         assertEq(aeroManagerImpl.claimedAero(), oldClaimed);
         assertEq(aeroManagerImpl.claimedAero(address(aeroToken)), oldClaimed);
@@ -620,7 +693,7 @@ contract AeroManagerTest is DevTestSetup {
         AeroManager.AeroRecipient[] memory recipients1 = new AeroManager.AeroRecipient[](1);
         recipients1[0] = AeroManager.AeroRecipient({borrower: B, amount: newClaimed});
         vm.prank(governor);
-        aeroManagerImpl.distributeAero(address(gauge), recipients1);
+        aeroManagerImpl.distributeAero(address(gauge), recipients1, true);
 
         assertEq(aeroManagerImpl.claimedAero(), newClaimed);
         assertEq(aeroManagerImpl.claimedAero(address(newTok)), newClaimed);


### PR DESCRIPTION
This PR makes changes to help with 2 things.

First, `distributeAero` can be called multiple times until all claimed AERO in current epoch are distributed. This helps for distributions to vastly large number of recipients if needed.

Second, the new function `startNextEpoch` is predominantly for alleviating 1 edge case: updating the AERO token address without disrupting currently ongoing epochs. It allows the governor to close all epochs, distribute AERO rewards, update AERO token address. Epochs for old gauges can remain closed as borrowers move to new AERO LP branches with gauges to new AERO token.

Still enable option to start next epoch immediately upon all rewards being allocated.