### PR TITLE
Fix s80: Calculate Aero pool TWAP prices by total elapsed time rather than points

### DIFF
--- a/contracts/src/PriceFeeds/AeroLPTokenPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/AeroLPTokenPriceFeedBase.sol
@@ -70,6 +70,8 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
     uint256 public constant TOKEN_PRICE_DEVIATION_THRESHOLD = 2e16; // 2%
     uint256 public constant TWAP_GRANULARITY = 8; // 8 periods × 30 min = 4 hours
 
+    uint256 internal constant OBSERVATION_PERIOD = 30 minutes;
+
     bool internal immutable _deployed;
     
     constructor(
@@ -158,15 +160,14 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
     function getExchangeRates(uint256 amountIn, uint256 granularity) public view returns (uint256, uint256) {
         uint256 amount0In = amountIn * 10 ** token0PoolDecimals;
         uint256 amount1In = amountIn * 10 ** token1PoolDecimals;
-        (uint256[] memory _prices0, uint256[] memory _prices1) = _sample(amount0In, amount1In, granularity);
+        SampleResults memory results = _sample(amount0In, amount1In, granularity);
         uint256 priceAverageCumulative0;
         uint256 priceAverageCumulative1;
-        uint256 _length = _prices0.length;
-        for (uint256 i = 0; i < _length; i++) {
-            priceAverageCumulative0 += _prices0[i];
-            priceAverageCumulative1 += _prices1[i];
+        for (uint256 i = 0; i < results.usedLength; i++) {
+            priceAverageCumulative0 += results.prices0[i];
+            priceAverageCumulative1 += results.prices1[i];
         }
-        return (priceAverageCumulative0 / granularity, priceAverageCumulative1 / granularity);
+        return (priceAverageCumulative0 / results.totalTimeElapsed, priceAverageCumulative1 / results.totalTimeElapsed);
     }
 
     ////////////////////////////////////////////////////////////////
@@ -177,23 +178,31 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
     // and reduce some redundancies when fetching both reserves and prices.
     ////////////////////////////////////////////////////////////////
 
+    struct SampleResults {
+        uint256[] prices0; // Prices of token0
+        uint256[] prices1; // Prices of token1
+        uint256 totalTimeElapsed; // Total time elapsed in the sample
+        uint256 usedLength; // Total length of the sample used (may not equal array length)
+    }
+
     /// @notice Sample the pool reserves and calculate the prices
+    /// @dev The sample may not loop through all the points if the total time elapsed exceeds the minimum total observation period
     /// @param amount0In Amount of token0 in
     /// @param amount1In Amount of token1 in
     /// @param points Number of points to sample
-    /// @return _prices0 Prices of token0
-    /// @return _prices1 Prices of token1
+    /// @return results Sample results
     function _sample(
         uint256 amount0In,
         uint256 amount1In,
         uint256 points
-    ) internal view returns (uint256[] memory, uint256[] memory) {
-        uint256[] memory _prices0 = new uint256[](points);
-        uint256[] memory _prices1 = new uint256[](points);
+    ) internal view returns (SampleResults memory results) {
+        results.prices0 = new uint256[](points);
+        results.prices1 = new uint256[](points);
 
         uint256 length = pool.observationLength() - 1;
         uint256 i = length - points;
         uint256 index = 0;
+        uint256 maxTimeElapsed = OBSERVATION_PERIOD * points;
 
         for (; i < length; i += 1) {
             IAeroPool.Observation memory nextObs = pool.observations(i + 1);
@@ -203,14 +212,21 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
                 timeElapsed;
             uint256 _reserve1 = (nextObs.reserve1Cumulative - currentObs.reserve1Cumulative) /
                 timeElapsed;
-            _prices0[index] = _getAmountOut(amount0In, pool.token0(), _reserve0, _reserve1);
-            _prices1[index] = _getAmountOut(amount1In, pool.token1(), _reserve0, _reserve1);
+            results.prices0[index] = _getAmountOut(amount0In, pool.token0(), _reserve0, _reserve1);
+            results.prices1[index] = _getAmountOut(amount1In, pool.token1(), _reserve0, _reserve1);
+            
+            results.totalTimeElapsed += timeElapsed;
+            if (results.totalTimeElapsed >= maxTimeElapsed) {
+                break;
+            }
+            
             // index < length; length cannot overflow
             unchecked {
                 index = index + 1;
             }
         }
-        return (_prices0, _prices1);
+        results.usedLength = index;
+        return results;
     }
 
     function _getAmountOut(

--- a/contracts/src/PriceFeeds/AeroLPTokenPriceFeedBase.sol
+++ b/contracts/src/PriceFeeds/AeroLPTokenPriceFeedBase.sol
@@ -164,8 +164,8 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
         uint256 priceAverageCumulative0;
         uint256 priceAverageCumulative1;
         for (uint256 i = 0; i < results.usedLength; i++) {
-            priceAverageCumulative0 += results.prices0[i];
-            priceAverageCumulative1 += results.prices1[i];
+            priceAverageCumulative0 += results.prices0[i] * results.timeElapsed[i];
+            priceAverageCumulative1 += results.prices1[i] * results.timeElapsed[i];
         }
         return (priceAverageCumulative0 / results.totalTimeElapsed, priceAverageCumulative1 / results.totalTimeElapsed);
     }
@@ -181,6 +181,7 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
     struct SampleResults {
         uint256[] prices0; // Prices of token0
         uint256[] prices1; // Prices of token1
+        uint256[] timeElapsed; // Time elapsed between each observation
         uint256 totalTimeElapsed; // Total time elapsed in the sample
         uint256 usedLength; // Total length of the sample used (may not equal array length)
     }
@@ -198,31 +199,32 @@ abstract contract AeroLPTokenPriceFeedBase is IPriceFeed {
     ) internal view returns (SampleResults memory results) {
         results.prices0 = new uint256[](points);
         results.prices1 = new uint256[](points);
+        results.timeElapsed = new uint256[](points);
 
         uint256 length = pool.observationLength() - 1;
-        uint256 i = length - points;
         uint256 index = 0;
         uint256 maxTimeElapsed = OBSERVATION_PERIOD * points;
 
-        for (; i < length; i += 1) {
-            IAeroPool.Observation memory nextObs = pool.observations(i + 1);
+        for (uint256 i = length; i > length - points; i -= 1) {
+            IAeroPool.Observation memory prevObs = pool.observations(i - 1);
             IAeroPool.Observation memory currentObs = pool.observations(i);
-            uint256 timeElapsed = nextObs.timestamp - currentObs.timestamp;
-            uint256 _reserve0 = (nextObs.reserve0Cumulative - currentObs.reserve0Cumulative) /
+            uint256 timeElapsed = currentObs.timestamp - prevObs.timestamp;
+            uint256 _reserve0 = (currentObs.reserve0Cumulative - prevObs.reserve0Cumulative) /
                 timeElapsed;
-            uint256 _reserve1 = (nextObs.reserve1Cumulative - currentObs.reserve1Cumulative) /
+            uint256 _reserve1 = (currentObs.reserve1Cumulative - prevObs.reserve1Cumulative) /
                 timeElapsed;
             results.prices0[index] = _getAmountOut(amount0In, pool.token0(), _reserve0, _reserve1);
             results.prices1[index] = _getAmountOut(amount1In, pool.token1(), _reserve0, _reserve1);
-            
-            results.totalTimeElapsed += timeElapsed;
-            if (results.totalTimeElapsed >= maxTimeElapsed) {
-                break;
-            }
+            results.timeElapsed[index] = timeElapsed;
             
             // index < length; length cannot overflow
             unchecked {
                 index = index + 1;
+            }
+
+            results.totalTimeElapsed += timeElapsed;
+            if (results.totalTimeElapsed >= maxTimeElapsed) {
+                break;
             }
         }
         results.usedLength = index;

--- a/contracts/test/TestContracts/AeroGaugeMock.sol
+++ b/contracts/test/TestContracts/AeroGaugeMock.sol
@@ -39,6 +39,8 @@ contract AeroPoolMock {
     uint256 internal _twapReserve0;
     uint256 internal _twapReserve1;
     bool internal _useTwapReserves;
+    Observation[] internal _customObservations;
+    bool internal _useCustomObservations;
 
     bool internal _shouldRevert;
     bool internal _isStable;
@@ -89,6 +91,14 @@ contract AeroPoolMock {
         _twapReserve0 = token0Unit;
         _twapReserve1 = token0ToToken1;
         _useTwapReserves = true;
+    }
+
+    function setObservations(Observation[] calldata newObservations) external {
+        delete _customObservations;
+        for (uint256 i = 0; i < newObservations.length; i++) {
+            _customObservations.push(newObservations[i]);
+        }
+        _useCustomObservations = true;
     }
 
     function setShouldRevert(bool v) external {
@@ -150,11 +160,13 @@ contract AeroPoolMock {
 
     function observationLength() external view returns (uint256) {
         if (_shouldRevert) revert("AeroPoolMock: revert");
+        if (_useCustomObservations) return _customObservations.length;
         return 9;
     }
 
     function observations(uint256 index) external view returns (Observation memory) {
         if (_shouldRevert) revert("AeroPoolMock: revert");
+        if (_useCustomObservations) return _customObservations[index];
         uint256 reserve0 = _useTwapReserves ? _twapReserve0 : _reserve0;
         uint256 reserve1 = _useTwapReserves ? _twapReserve1 : _reserve1;
         return Observation({

--- a/contracts/test/aeroLPTokenPriceFeed.t.sol
+++ b/contracts/test/aeroLPTokenPriceFeed.t.sol
@@ -88,6 +88,31 @@ contract AeroLPTokenPriceFeedTest is Test {
         );
     }
 
+    function _setObservations(uint256[] memory durations, uint256[] memory token1PerToken0) internal {
+        assertEq(durations.length, token1PerToken0.length);
+
+        AeroPoolMock.Observation[] memory newObservations = new AeroPoolMock.Observation[](durations.length + 1);
+        uint256 timestamp;
+        uint256 reserve0Cumulative;
+        uint256 reserve1Cumulative;
+        uint256 reserve0 = 1e6;
+
+        newObservations[0] = AeroPoolMock.Observation({
+            timestamp: timestamp, reserve0Cumulative: reserve0Cumulative, reserve1Cumulative: reserve1Cumulative
+        });
+
+        for (uint256 i = 0; i < durations.length; i++) {
+            timestamp += durations[i];
+            reserve0Cumulative += reserve0 * durations[i];
+            reserve1Cumulative += token1PerToken0[i] * durations[i];
+            newObservations[i + 1] = AeroPoolMock.Observation({
+                timestamp: timestamp, reserve0Cumulative: reserve0Cumulative, reserve1Cumulative: reserve1Cumulative
+            });
+        }
+
+        pool.setObservations(newObservations);
+    }
+
     // ============ TWAP Exchange Rate Tests ============
 
     function test_constructor_revertsWhenGaugeIsZero() public {
@@ -127,6 +152,60 @@ contract AeroLPTokenPriceFeedTest is Test {
         assertEq(exchangeRate.token1PerToken0, 0.0005e18);
         assertEq(exchangeRate.token0PerToken1, 2000e18);
         assertFalse(exchangeRate.isDown);
+    }
+
+    function test_getExchangeRates_weightsUnequalObservationDurations() public {
+        uint256[] memory durations = new uint256[](3);
+        durations[0] = 1801;
+        durations[1] = 1802;
+        durations[2] = 1803;
+
+        uint256[] memory token1PerToken0 = new uint256[](3);
+        token1PerToken0[0] = 100e18;
+        token1PerToken0[1] = 200e18;
+        token1PerToken0[2] = 400e18;
+        _setObservations(durations, token1PerToken0);
+
+        (uint256 actualToken1PerToken0, uint256 actualToken0PerToken1) = feed.getExchangeRates(1, 3);
+
+        uint256 totalTimeElapsed = durations[0] + durations[1] + durations[2];
+        uint256 expectedToken1PerToken0 =
+            (token1PerToken0[0] * durations[0] + token1PerToken0[1] * durations[1] + token1PerToken0[2] * durations[2])
+                / totalTimeElapsed;
+        uint256 expectedToken0PerToken1 =
+            ((1e24 / token1PerToken0[0])
+                    * durations[0]
+                    + (1e24 / token1PerToken0[1])
+                    * durations[1]
+                    + (1e24 / token1PerToken0[2])
+                    * durations[2]) / totalTimeElapsed;
+
+        assertEq(actualToken1PerToken0, expectedToken1PerToken0);
+        assertEq(actualToken0PerToken1, expectedToken0PerToken1);
+    }
+
+    function test_getExchangeRates_earlyBreakUsesNewestIntervalsAndIncludesBoundary() public {
+        uint256[] memory durations = new uint256[](5);
+        durations[0] = 1801;
+        durations[1] = 1801;
+        durations[2] = 1801;
+        durations[3] = 5000;
+        durations[4] = 5000;
+
+        uint256[] memory token1PerToken0 = new uint256[](5);
+        token1PerToken0[0] = 900e18;
+        token1PerToken0[1] = 800e18;
+        token1PerToken0[2] = 700e18;
+        token1PerToken0[3] = 100e18;
+        token1PerToken0[4] = 200e18;
+        _setObservations(durations, token1PerToken0);
+
+        (uint256 actualToken1PerToken0, uint256 actualToken0PerToken1) = feed.getExchangeRates(1, 5);
+
+        // The newest two 5,000-second intervals exceed the 9,000-second target.
+        // The older three intervals must not affect either returned exchange rate.
+        assertEq(actualToken1PerToken0, 150e18);
+        assertEq(actualToken0PerToken1, 7500);
     }
 
     function test_getTwapExchangeRate_stablePairCoversBothTokenDirections() public {


### PR DESCRIPTION
`AeroLPTokenPriceFeedBased.getExchangeRate()` assumes each observation period is 30 minutes which is only the guaranteed minimum duration for each period. This change is stricter in keeping total time elapsed within TWAP expectation and more accurate by dividing by total elapsed time instead of by granularity points