### PR TITLE
Fix s95 (post-review): fetch canonical rate without self call in constructor

### DIFF
--- a/contracts/src/PriceFeeds/RETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/RETHPriceFeed.sol
@@ -9,6 +9,8 @@ import "../Interfaces/IRETHPriceFeed.sol";
 // import "forge-std/console2.sol";
 
 contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
+    bool private immutable _deployed = false;
+    
     constructor(
         address _ethUsdOracleAddress,
         address _rEthEthOracleAddress,
@@ -31,6 +33,7 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
 
         // Check the oracle didn't already fail
         assert(priceSource == PriceSource.primary);
+        _deployed = true;
     }
 
     Oracle public rEthEthOracle;
@@ -93,6 +96,14 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
     }
 
     function _getCanonicalRate() internal view override returns (uint256, bool) {
+        if (!_deployed) {
+            (uint256 ethPerReth, uint256 lastUpdated) = getCanonicalRate();
+            if (lastUpdated + canonicalRateStalenessThreshold <= block.timestamp) {
+                return (0, true);
+            }
+            return (ethPerReth, false);
+        }
+
         uint256 gasBefore = gasleft();
 
         try this.getCanonicalRate() returns (uint256 ethPerReth, uint256 lastUpdated) {

--- a/contracts/test/priceFeeds/RETHPriceFeed.t.sol
+++ b/contracts/test/priceFeeds/RETHPriceFeed.t.sol
@@ -32,6 +32,10 @@ contract ToggleRethToken {
         if (fail) revert();
         return _rate;
     }
+
+    function lastUpdated() external view returns (uint256) {
+        return block.timestamp;
+    }
 }
 
 contract RETHPriceFeedTest is Test {


### PR DESCRIPTION
The self call in `_getCanonicalRate()` does not work in the constructor.