### PR TITLE
Move `_deployed` for consistency with other pricefeed

### DIFF
--- a/contracts/src/PriceFeeds/RETHPriceFeed.sol
+++ b/contracts/src/PriceFeeds/RETHPriceFeed.sol
@@ -31,9 +31,10 @@ contract RETHPriceFeed is CompositePriceFeed, IRETHPriceFeed {
 
         _fetchPricePrimary(false);
 
+        _deployed = true;
+        
         // Check the oracle didn't already fail
         assert(priceSource == PriceSource.primary);
-        _deployed = true;
     }
 
     Oracle public rEthEthOracle;


### PR DESCRIPTION
This is purely for visual consistency of operations order between AeroLPTokenPriceFeed and RETHPriceFeed.